### PR TITLE
docs: README.mdにonly/excludeフラグの説明を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ $ backlog-exporter document --domain example.backlog.jp --projectIdOrKey PROJECT
 # 課題・Wiki・ドキュメントの一括エクスポート
 $ backlog-exporter all --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --output ./backlog-data
 
+# 特定のデータタイプのみをエクスポート（onlyフラグ）
+$ backlog-exporter all --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --only issues,wiki
+
+# 特定のデータタイプを除外してエクスポート（excludeフラグ）
+$ backlog-exporter all --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --exclude documents
+
 # データの更新
 $ backlog-exporter update
 ```
@@ -220,9 +226,43 @@ $ backlog-exporter all --domain example.backlog.jp --projectIdOrKey PROJECT_KEY 
 
 # 出力先を指定
 $ backlog-exporter all --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --output ./backlog-data
+
+# 特定のデータタイプのみをエクスポート（onlyフラグ）
+$ backlog-exporter all --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --only issues,wiki
+
+# 特定のデータタイプを除外してエクスポート（excludeフラグ）
+$ backlog-exporter all --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --exclude documents
 ```
 
 一括エクスポートでは、課題は`issues`ディレクトリに、Wiki は`wiki`ディレクトリに、ドキュメントは`documents`ディレクトリに保存されます。
+
+## エクスポート対象の制御
+
+`all`コマンドでは、以下のフラグを使用してエクスポート対象を制御できます：
+
+### --only フラグ
+特定のデータタイプのみをエクスポートします。カンマ区切りで複数指定可能です。
+
+```sh
+# 課題とWikiのみをエクスポート
+$ backlog-exporter all --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --only issues,wiki
+
+# ドキュメントのみをエクスポート
+$ backlog-exporter all --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --only documents
+```
+
+### --exclude フラグ
+特定のデータタイプを除外してエクスポートします。カンマ区切りで複数指定可能です。
+
+```sh
+# ドキュメント以外（課題とWiki）をエクスポート
+$ backlog-exporter all --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --exclude documents
+
+# 課題以外（WikiとDocuments）をエクスポート
+$ backlog-exporter all --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --exclude issues
+```
+
+**注意**: `--only`と`--exclude`フラグは同時に使用できません。どちらか一方を使用してください。
 
 # データの更新
 


### PR DESCRIPTION
## Summary
- README.mdに新しく追加された`--only`と`--exclude`フラグの説明を追加

## Changes
### 基本的な使用例の更新
- コマンド例に`--only`と`--exclude`フラグの使用例を追加

### 一括エクスポートセクションの拡充
- `all`コマンドのエクスポート対象制御機能の詳細説明を追加
- `--only`フラグ: 特定のデータタイプのみをエクスポート
- `--exclude`フラグ: 特定のデータタイプを除外してエクスポート
- 各フラグの使用例とオプション値の説明
- フラグの競合に関する注意事項

## Documentation coverage
- [x] 基本的な使用例にフラグの例を追加
- [x] 一括エクスポートセクションに詳細な説明を追加
- [x] --onlyフラグの説明と使用例
- [x] --excludeフラグの説明と使用例
- [x] フラグの競合についての注意事項
- [x] カンマ区切りでの複数指定方法の説明

## Usage examples added
```bash
# 特定のデータタイプのみをエクスポート
backlog-exporter all --only issues,wiki

# 特定のデータタイプを除外してエクスポート  
backlog-exporter all --exclude documents
```

🤖 Generated with [Claude Code](https://claude.ai/code)