### PR TITLE
feat: 課題エクスポート機能に、課題キー名のフォルダを作成し、課題キーをファイル名に作成指定できるオプションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,14 @@ $ backlog-exporter issue --domain example.backlog.jp --projectIdOrKey PROJECT_KE
 # 出力先を指定
 $ backlog-exporter issue --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --output ./issues
 
-# 課題キーでフォルダを作成し、その中に課題キー名のMarkdownファイルを出力
-$ backlog-exporter issue --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --useIssueKeyFolder
+# Markdownファイル名を課題キーにする
+$ backlog-exporter issue --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --issueKeyFileName
+
+# 課題キーでフォルダを作成する
+$ backlog-exporter issue --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --issueKeyFolder
+
+# 課題キーでフォルダを作成し、Markdownファイル名も課題キーにする
+$ backlog-exporter issue --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --issueKeyFileName --issueKeyFolder
 ```
 
 エクスポートされた課題は、指定したディレクトリ内に Markdown ファイルとして保存されます。ファイル名は課題のキーに基づいて自動的に生成されます。

--- a/src/commands/all/index.ts
+++ b/src/commands/all/index.ts
@@ -28,8 +28,14 @@ export default class All extends Command {
     `<%= config.bin %> <%= command.id %> --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --maxCount 1000
 最大1000件の課題を取得する（デフォルトは5000件）
 `,
-    `<%= config.bin %> <%= command.id %> --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --useIssueKeyFolder
-課題キーでフォルダを作成し、その中に課題キー名のMarkdownファイルを出力する
+    `<%= config.bin %> <%= command.id %> --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --issueKeyFileName
+ファイル名を課題キーにする
+`,
+    `<%= config.bin %> <%= command.id %> --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --issueKeyFolder
+課題キーでフォルダを作成する
+`,
+    `<%= config.bin %> <%= command.id %> --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --issueKeyFileName --issueKeyFolder
+課題キーでフォルダを作成し、ファイル名も課題キーにする
 `,
   ]
   static flags = {
@@ -43,6 +49,14 @@ export default class All extends Command {
     }),
     exclude: Flags.string({
       description: "Exclude the specified types, separated by commas (e.g., 'documents,wiki')",
+      required: false,
+    }),
+    issueKeyFileName: Flags.boolean({
+      description: 'ファイル名を課題キーにする',
+      required: false,
+    }),
+    issueKeyFolder: Flags.boolean({
+      description: '課題キーでフォルダを作成する',
       required: false,
     }),
     maxCount: Flags.integer({
@@ -64,17 +78,13 @@ export default class All extends Command {
       description: 'Backlog project ID or key',
       required: true,
     }),
-    useIssueKeyFolder: Flags.boolean({
-      description: '課題キーでフォルダを作成し、その中に課題キー名のMarkdownファイルを出力する',
-      required: false,
-    }),
   }
 
   async run(): Promise<void> {
     const {flags} = await this.parse(All)
 
     try {
-      const {domain, exclude, maxCount, only, projectIdOrKey, useIssueKeyFolder} = flags
+      const {domain, exclude, issueKeyFileName, issueKeyFolder, maxCount, only, projectIdOrKey} = flags
       const apiKey = flags.apiKey || getApiKey(this)
       const outputRoot = flags.output || './backlog-data'
 
@@ -126,6 +136,8 @@ export default class All extends Command {
           apiKey,
           domain,
           folderType: FolderType.ISSUE,
+          issueKeyFileName,
+          issueKeyFolder,
           outputDir: issueOutput,
           projectIdOrKey,
         })
@@ -136,9 +148,10 @@ export default class All extends Command {
           apiKey,
           count: maxCount,
           domain,
+          issueKeyFileName,
+          issueKeyFolder,
           outputDir: issueOutput,
           projectId,
-          useIssueKeyFolder,
         })
 
         // 課題フォルダの最終更新日時を更新

--- a/src/commands/issue/index.ts
+++ b/src/commands/issue/index.ts
@@ -24,8 +24,14 @@ export default class Issue extends Command {
     `<%= config.bin %> <%= command.id %> --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --maxCount 10000
 最大10000件の課題を取得する（デフォルトは5000件）
 `,
-    `<%= config.bin %> <%= command.id %> --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --useIssueKeyFolder
-課題キーでフォルダを作成し、その中に課題キー名のMarkdownファイルを出力する
+    `<%= config.bin %> <%= command.id %> --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --issueKeyFileName
+ファイル名を課題キーにする
+`,
+    `<%= config.bin %> <%= command.id %> --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --issueKeyFolder
+課題キーでフォルダを作成する
+`,
+    `<%= config.bin %> <%= command.id %> --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --issueKeyFileName --issueKeyFolder
+課題キーでフォルダを作成し、ファイル名も課題キーにする
 `,
   ]
   static flags = {
@@ -36,6 +42,14 @@ export default class Issue extends Command {
     domain: Flags.string({
       description: 'Backlog domain (e.g. example.backlog.jp)',
       required: true,
+    }),
+    issueKeyFileName: Flags.boolean({
+      description: 'ファイル名を課題キーにする',
+      required: false,
+    }),
+    issueKeyFolder: Flags.boolean({
+      description: '課題キーでフォルダを作成する',
+      required: false,
     }),
     maxCount: Flags.integer({
       char: 'm',
@@ -56,17 +70,13 @@ export default class Issue extends Command {
       description: 'ステータスID（カンマ区切りで複数指定可能）',
       required: false,
     }),
-    useIssueKeyFolder: Flags.boolean({
-      description: '課題キーでフォルダを作成し、その中に課題キー名のMarkdownファイルを出力する',
-      required: false,
-    }),
   }
 
   async run(): Promise<void> {
     const {flags} = await this.parse(Issue)
 
     try {
-      const {domain, maxCount, projectIdOrKey, statusId, useIssueKeyFolder} = flags
+      const {domain, issueKeyFileName, issueKeyFolder, maxCount, projectIdOrKey, statusId} = flags
       const apiKey = flags.apiKey || getApiKey(this)
       const outputDir = flags.output || './backlog-issues'
 
@@ -82,6 +92,8 @@ export default class Issue extends Command {
         apiKey,
         domain,
         folderType: FolderType.ISSUE,
+        issueKeyFileName,
+        issueKeyFolder,
         outputDir,
         projectIdOrKey,
       })
@@ -91,10 +103,11 @@ export default class Issue extends Command {
         apiKey,
         count: maxCount,
         domain,
+        issueKeyFileName,
+        issueKeyFolder,
         outputDir,
         projectId,
         statusId,
-        useIssueKeyFolder,
       })
 
       // 最終更新日時を更新

--- a/src/utils/backlog-api.ts
+++ b/src/utils/backlog-api.ts
@@ -64,7 +64,8 @@ export function createCustomFieldsSection(customFields?: Array<{
  * @param options.outputDir 出力ディレクトリ
  * @param options.projectId プロジェクトID
  * @param options.statusId ステータスID
- * @param options.useIssueKeyFolder 課題キーでフォルダを作成するかどうか
+ * @param options.issueKeyFileName ファイル名を課題キーにするかどうか
+ * @param options.issueKeyFolder 課題キーでフォルダを作成するかどうか
  */
 export async function downloadIssues(
   command: Command,
@@ -72,11 +73,12 @@ export async function downloadIssues(
     apiKey: string
     count?: number
     domain: string
+    issueKeyFileName?: boolean
+    issueKeyFolder?: boolean
     lastUpdated?: string
     outputDir: string
     projectId: number
     statusId?: string
-    useIssueKeyFolder?: boolean
   },
 ): Promise<void> {
   const baseUrl = `https://${options.domain}/api/v2`
@@ -260,16 +262,18 @@ export async function downloadIssues(
       let issueFilePath: string
       let issueFileName: string
 
-      if (options.useIssueKeyFolder) {
-        // 年ごとのフォルダ内に、課題キーでフォルダを作成し、その中に課題キー名のMarkdownファイルを保存
+      if (options.issueKeyFolder) {
+        // 年ごとのフォルダ内に、課題キーでフォルダを作成
         const issueKeyDirPath = path.join(yearDirPath, issue.issueKey)
+        // eslint-disable-next-line no-await-in-loop
         await fs.mkdir(issueKeyDirPath, {recursive: true})
         
-        issueFileName = `${issue.issueKey}.md`
+        // ファイル名を課題名（標準）にするか課題キーにするかを決定
+        issueFileName = options.issueKeyFileName ? `${issue.issueKey}.md` : `${sanitizeFileName(issue.summary)}.md`;
         issueFilePath = path.join(issueKeyDirPath, issueFileName)
       } else {
-        // 年ごとのフォルダ内にMarkdownファイルを保存
-        issueFileName = `${sanitizeFileName(issue.summary)}.md`
+        // 年ごとのフォルダ内に、Markdownファイルを作成
+        issueFileName = options.issueKeyFileName ? `${issue.issueKey}.md` : `${sanitizeFileName(issue.summary)}.md`;
         issueFilePath = path.join(yearDirPath, issueFileName)
       }
 

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -17,6 +17,8 @@ export interface Settings {
   apiKey?: string
   domain?: string
   folderType?: FolderType
+  issueKeyFileName?: boolean
+  issueKeyFolder?: boolean
   lastUpdated?: string
   outputDir?: string
   projectIdOrKey?: string

--- a/test/commands/issue-use-issue-key-folder.test.ts
+++ b/test/commands/issue-use-issue-key-folder.test.ts
@@ -1,68 +1,122 @@
 import {expect} from 'chai'
 import {describe, it} from 'mocha'
 
-import Issue from '../../src/commands/issue/index.js'
 import All from '../../src/commands/all/index.js'
+import Issue from '../../src/commands/issue/index.js'
 import Update from '../../src/commands/update/index.js'
 
-describe('useIssueKeyFolderフラグ', () => {
+describe('issueKeyFileName/issueKeyFolderフラグ', () => {
   describe('Issueコマンド', () => {
-    it('useIssueKeyFolderフラグが定義されていること', () => {
+    it('issueKeyFileNameフラグが定義されていること', () => {
       const {flags} = Issue
 
-      expect(flags.useIssueKeyFolder).to.exist
-      expect(flags.useIssueKeyFolder.required).to.be.false
-      expect(flags.useIssueKeyFolder.description).to.include('課題キーでフォルダを作成')
+      expect(flags.issueKeyFileName).to.exist
+      expect(flags.issueKeyFileName.required).to.be.false
+      expect(flags.issueKeyFileName.description).to.include('ファイル名を課題キー')
     })
 
-    it('useIssueKeyFolderの使用例が存在すること', () => {
+    it('issueKeyFolderフラグが定義されていること', () => {
+      const {flags} = Issue
+
+      expect(flags.issueKeyFolder).to.exist
+      expect(flags.issueKeyFolder.required).to.be.false
+      expect(flags.issueKeyFolder.description).to.include('課題キーでフォルダ')
+    })
+
+    it('issueKeyFileNameの使用例が存在すること', () => {
       const {examples} = Issue
 
-      const hasUseIssueKeyFolderExample = examples.some((ex) => 
-        ex.includes('--useIssueKeyFolder')
+      const hasIssueKeyFileNameExample = examples.some((ex) => 
+        ex.includes('--issueKeyFileName')
       )
 
-      expect(hasUseIssueKeyFolderExample).to.be.true
+      expect(hasIssueKeyFileNameExample).to.be.true
+    })
+
+    it('issueKeyFolderの使用例が存在すること', () => {
+      const {examples} = Issue
+
+      const hasIssueKeyFolderExample = examples.some((ex) => 
+        ex.includes('--issueKeyFolder')
+      )
+
+      expect(hasIssueKeyFolderExample).to.be.true
     })
   })
 
   describe('Allコマンド', () => {
-    it('useIssueKeyFolderフラグが定義されていること', () => {
+    it('issueKeyFileNameフラグが定義されていること', () => {
       const {flags} = All
 
-      expect(flags.useIssueKeyFolder).to.exist
-      expect(flags.useIssueKeyFolder.required).to.be.false
-      expect(flags.useIssueKeyFolder.description).to.include('課題キーでフォルダを作成')
+      expect(flags.issueKeyFileName).to.exist
+      expect(flags.issueKeyFileName.required).to.be.false
+      expect(flags.issueKeyFileName.description).to.include('ファイル名を課題キー')
     })
 
-    it('useIssueKeyFolderの使用例が存在すること', () => {
+    it('issueKeyFolderフラグが定義されていること', () => {
+      const {flags} = All
+
+      expect(flags.issueKeyFolder).to.exist
+      expect(flags.issueKeyFolder.required).to.be.false
+      expect(flags.issueKeyFolder.description).to.include('課題キーでフォルダ')
+    })
+
+    it('issueKeyFileNameの使用例が存在すること', () => {
       const {examples} = All
 
-      const hasUseIssueKeyFolderExample = examples.some((ex) => 
-        ex.includes('--useIssueKeyFolder')
+      const hasIssueKeyFileNameExample = examples.some((ex) => 
+        ex.includes('--issueKeyFileName')
       )
 
-      expect(hasUseIssueKeyFolderExample).to.be.true
+      expect(hasIssueKeyFileNameExample).to.be.true
+    })
+
+    it('issueKeyFolderの使用例が存在すること', () => {
+      const {examples} = All
+
+      const hasIssueKeyFolderExample = examples.some((ex) => 
+        ex.includes('--issueKeyFolder')
+      )
+
+      expect(hasIssueKeyFolderExample).to.be.true
     })
   })
 
   describe('Updateコマンド', () => {
-    it('useIssueKeyFolderフラグが定義されていること', () => {
+    it('issueKeyFileNameフラグが定義されていること', () => {
       const {flags} = Update
 
-      expect(flags.useIssueKeyFolder).to.exist
-      expect(flags.useIssueKeyFolder.required).to.be.false
-      expect(flags.useIssueKeyFolder.description).to.include('課題キーでフォルダを作成')
+      expect(flags.issueKeyFileName).to.exist
+      expect(flags.issueKeyFileName.required).to.be.false
+      expect(flags.issueKeyFileName.description).to.include('ファイル名を課題キー')
     })
 
-    it('useIssueKeyFolderの使用例が存在すること', () => {
+    it('issueKeyFolderフラグが定義されていること', () => {
+      const {flags} = Update
+
+      expect(flags.issueKeyFolder).to.exist
+      expect(flags.issueKeyFolder.required).to.be.false
+      expect(flags.issueKeyFolder.description).to.include('課題キーでフォルダ')
+    })
+
+    it('issueKeyFileNameの使用例が存在すること', () => {
       const {examples} = Update
 
-      const hasUseIssueKeyFolderExample = examples.some((ex) => 
-        ex.includes('--useIssueKeyFolder')
+      const hasIssueKeyFileNameExample = examples.some((ex) => 
+        ex.includes('--issueKeyFileName')
       )
 
-      expect(hasUseIssueKeyFolderExample).to.be.true
+      expect(hasIssueKeyFileNameExample).to.be.true
+    })
+
+    it('issueKeyFolderの使用例が存在すること', () => {
+      const {examples} = Update
+
+      const hasIssueKeyFolderExample = examples.some((ex) => 
+        ex.includes('--issueKeyFolder')
+      )
+
+      expect(hasIssueKeyFolderExample).to.be.true
     })
   })
 }) 


### PR DESCRIPTION
@ShuntaToda はじめまして。backlog-exporter をとても便利に利用させていただいております。
すばらしいツールをありがとうございます。

今回、課題エクスポート機能に、課題キーでフォルダを作成し、その中に課題キー名のMarkdownファイルを出力するオプション `--useIssueKeyFolder` を追加してみました。

## 変更理由

普段の利用時に、以下のケースでの利用シーンを取り入れたかったためです。

- 課題キーのフォルダ名とすることで、課題の関連資料（スクリーンショットやドキュメント類）をフォルダ内に収めて管理できるようにしたかったこと
- 課題用の Markdownファイルを vscode といったIDEで、Cmd＋P でのファイル名検索時に、課題キーで探したかったこと
- 課題タイトルが変更となるケースがあるため、一意の課題キーを用いることで保ちたかったこと
- 課題キーをファイル名に含むことで、Gitでの差分確認時にどの課題の変更かをわかりやすくしたかったこと

## 変更内容

### 新機能
- `--useIssueKeyFolder` フラグを追加
  - `issue` コマンド
  - `all` コマンド
  - `update` コマンド

### 動作

- 通常使用（変更なし）: `2025/課題タイトル.md`
- useIssueKeyFolder オプション使用: `2025/PROJECT-123/PROJECT-123.md`

## 使用例

README.md に使用例を追加しております。

```bash
# 課題キーでフォルダを作成してエクスポート
node bin/run.js issue --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --useIssueKeyFolder

# 全データをエクスポート（課題は課題キーでフォルダ作成）
node bin/run.js all --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --useIssueKeyFolder

# 更新時に課題キーでフォルダ作成
node bin/run.js update --useIssueKeyFolder
```

差し支えございませんでしたら、本プルリク内容の取込みをご検討いただけますと幸いです。
よろしくお願いします。
