### PR TITLE
feat: 課題エクスポートのコメントにBacklogコメントへのリンクを追加

### DIFF
--- a/src/utils/backlog-api.ts
+++ b/src/utils/backlog-api.ts
@@ -248,9 +248,11 @@ export async function downloadIssues(
         let commentIndex = 1
         for (const comment of allComments) {
           const commentDate = new Date(comment.created).toLocaleString('ja-JP')
+          // Backlogのコメントへのリンクを作成
+          const backlogCommentUrl = `${backlogIssueUrl}#comment-${comment.id}`
           commentsSection += `\n### コメント ${commentIndex}\n- **投稿者**: ${
             comment.createdUser.name
-          }\n- **日時**: ${commentDate}\n\n${comment.content || '(内容なし)'}\n\n---\n`
+          }\n- **日時**: ${commentDate}\n- [Backlog Comment Link](${backlogCommentUrl})\n\n${comment.content || '(内容なし)'}\n\n---\n`
           commentIndex++
         }
 


### PR DESCRIPTION
## 概要

課題エクスポートのコメントセクションに、Backlog上の該当コメントへのリンク（`[Backlog Comment Link]`）を追加します。

## 背景・モチベーション

課題本文には `[Backlog Issue Link]` がありますが、コメントにはBacklog上の該当コメントへ直接飛べるリンクがありません。エクスポートされたMarkdownを読みながら「このコメントをBacklog上で確認・返信したい」となった際に、課題を開いてからコメントを探す手間が発生します。

Backlogのコメントは `https://{domain}/view/{課題キー}#comment-{コメントID}` 形式のパーマリンクを持つため、エクスポート時にこのリンクを付与します。

## 変更内容

各コメントのメタ情報（投稿者・日時）の直後に1行追加します。

```markdown
### コメント 1
- **投稿者**: 山田太郎
- **日時**: 2026/6/10 20:00:00
- [Backlog Comment Link](https://example.backlog.jp/view/TEST-1#comment-555)

コメント本文
```

リンクのラベルは既存の `[Backlog Issue Link]` / `[Backlog Wiki Link]` の命名に合わせて `[Backlog Comment Link]` としています。

## 動作確認

- `npm run build` / `npm test` 139件すべて成功 ✅
- nockでBacklog APIをモックしたE2E確認: 複数コメントそれぞれに正しいコメントIDのリンクが付与されることを確認 ✅
- 実Backlogプロジェクトでも実行し、実際のコメントIDでリンクが生成されることを確認 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
