### PR TITLE
ci: テストマトリクスからNode.js latestを除外しLTSのみにする

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
-        node_version: [lts/-1, lts/*, latest]
+        node_version: [lts/-1, lts/*]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## 概要

CI のテストマトリクスから `latest`（Node.js 最新版）を除外し、LTS（`lts/*`, `lts/-1`）のみに絞ります。

## 背景

Node.js `latest` は先行リリースで依存パッケージ（`yargs` 等）が未対応なことがあり、Node の新バージョンが公開されるたびに CI が突然失敗する状態でした。実際に Node v26.3.1 で `ReferenceError: require is not defined in ES module scope`（`yargs` 起因）によりテスト起動前にクラッシュしていました。

動作保証対象である LTS のみをテストする形にして、CI を安定させます。

## 変更内容

- `.github/workflows/test.yml` のマトリクス `node_version` から `latest` を削除

```diff
-        node_version: [lts/-1, lts/*, latest]
+        node_version: [lts/-1, lts/*]
```

## 動作確認

- 本ブランチの CI: ubuntu/windows × `lts/-1`/`lts/*` の4ジョブすべて success ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)