### PR TITLE
chore: v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ npm install -g backlog-exporter
 $ backlog-exporter COMMAND
 running command...
 $ backlog-exporter (--version)
-backlog-exporter/0.7.3 linux-x64 node-v22.23.1
+backlog-exporter/1.0.0 darwin-arm64 node-v22.22.2
 $ backlog-exporter --help [COMMAND]
 USAGE
   $ backlog-exporter COMMAND

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backlog-exporter",
-  "version": "0.7.3",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backlog-exporter",
-      "version": "0.7.3",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backlog-exporter",
   "description": "A new CLI generated with oclif",
-  "version": "0.7.3",
+  "version": "1.0.0",
   "author": "ShuntaToda",
   "bin": {
     "backlog-exporter": "bin/run.js"


### PR DESCRIPTION
## v1.0.0

v0.7.3以降の変更をまとめてメジャーリリースします。

### 新機能
- `prune`コマンド: Backlog上で削除・移動された課題・ドキュメント・Wikiのローカルファイルを削除（#46, #49）
- コメントの変更履歴（担当者・状態・カスタム属性の変更など）をMarkdownに出力（#49）
- `all`コマンドでWiki・ドキュメントの取得対象を対話選択（#49）
- 子を持つ親ドキュメントの本文を`00_index.md`として保存（#42）
- コメントリンク・課題キーオプション（#40, #41）
- 本文をマーカーで囲んで保存（#44）

### 破壊的変更
- **Node.js 22以上が必要**（Node 20はEOL）

### 内部改善（#49）
- module-first構成への全面リファクタリング（domain / repository / use-case + DI）
- 依存削減: ky→ネイティブfetch、mocha/chai→Vitest、dotenv/shx/ts-node/nockを削除
- 自前モックHTTPサーバによるテストとe2e結合テストの追加（テスト222件）
- 存在しないコマンド・ディレクトリ指定時のエラー表示改善

🤖 Generated with [Claude Code](https://claude.com/claude-code)