### PR TITLE
feat: 課題の添付ファイルをダウンロードする -d/--downloadAttachments フラグを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,24 @@ $ backlog-exporter issue --domain example.backlog.jp --projectIdOrKey PROJECT_KE
 $ backlog-exporter issue --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --issueKeyFileName --issueKeyFolder
 ```
 
+**課題の添付ファイルもダウンロードする**
+
+```sh
+$ backlog-exporter issue --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --downloadAttachments
+```
+
 エクスポートされた課題は、指定したディレクトリ内に Markdown ファイルとして保存されます。ファイル名は課題のキーに基づいて自動的に生成されます。
+
+## 添付ファイルのダウンロード
+
+`--downloadAttachments`（短縮形: `-d`）フラグを指定すると、課題の添付ファイルもダウンロードされます（`all` / `issue` / `update` コマンドで使用可能）。
+
+- 保存先はデフォルトでは `{年}/attachments/{課題キー}/`、`--issueKeyFolder` 指定時は課題フォルダ直下の `attachments/` です
+- ファイル名は同名の衝突を避けるため `{添付ID}_{ファイル名}` になります
+- Markdown の `## 添付ファイル` セクションにローカルファイルへの相対リンクが記載されます（フラグ未指定時はファイル名とサイズのみ記載）
+- 本文・コメント内の添付画像のインライン記法（`![image][ファイル名]` / `#image(ファイル名)`）は、ダウンロード済みファイルへの画像リンクに変換され、Markdownビューアでそのまま表示できます
+- ダウンロード済みのファイルは再ダウンロードされないため、`update` コマンドでの差分更新でも効率的に動作します
+- 設定は `backlog-settings.json` に保存され、以降の `update` コマンドで自動的に引き継がれます
 
 ## カスタム属性の対応
 

--- a/src/commands/all/base.test.ts
+++ b/src/commands/all/base.test.ts
@@ -66,3 +66,14 @@ describe('Allコマンド - 基本機能', () => {
     })
   })
 })
+
+describe('Allコマンド - 添付ファイルダウンロードフラグ', () => {
+  it('downloadAttachmentsフラグが正しく設定されていること', () => {
+    const {flags} = All
+
+    expect(flags.downloadAttachments).to.exist
+    expect(flags.downloadAttachments.required).to.be.false
+    expect(flags.downloadAttachments.char).to.equal('d')
+    expect(flags.downloadAttachments.description).to.include('添付ファイル')
+  })
+})

--- a/src/commands/all/index.ts
+++ b/src/commands/all/index.ts
@@ -48,6 +48,11 @@ export default class All extends Command {
       description: 'Backlog domain (e.g. example.backlog.jp)',
       required: true,
     }),
+    downloadAttachments: Flags.boolean({
+      char: 'd',
+      description: '課題の添付ファイルもダウンロードする',
+      required: false,
+    }),
     exclude: Flags.string({
       description: "Exclude the specified types, separated by commas (e.g., 'documents,wiki')",
       required: false,
@@ -85,7 +90,8 @@ export default class All extends Command {
     const {flags} = await this.parse(All)
 
     try {
-      const {domain, exclude, issueKeyFileName, issueKeyFolder, maxCount, only, projectIdOrKey} = flags
+      const {domain, downloadAttachments, exclude, issueKeyFileName, issueKeyFolder, maxCount, only, projectIdOrKey} =
+        flags
       const apiKey =
         resolveApiKey(flags.apiKey, () => this.log('環境変数 BACKLOG_API_KEY からAPIキーを使用します')) ??
         this.error(API_KEY_NOT_FOUND_MESSAGE)
@@ -104,6 +110,8 @@ export default class All extends Command {
       const repositories = createBacklogRepositories({
         apiKey,
         domain,
+        onRateLimitExceeded: (waitSeconds: number) =>
+          this.log(`レート制限の上限に達しました。${waitSeconds}秒待機します...`),
         onRateLimitWait: () => this.log('レート制限を回避するため15秒間待機します...'),
       })
 
@@ -112,6 +120,7 @@ export default class All extends Command {
         {
           apiKey,
           domain,
+          downloadAttachments,
           issueKeyFileName,
           issueKeyFolder,
           maxCount,

--- a/src/commands/document/index.ts
+++ b/src/commands/document/index.ts
@@ -61,6 +61,8 @@ export default class Document extends Command {
       const {documentRepository, projectRepository} = createBacklogRepositories({
         apiKey,
         domain,
+        onRateLimitExceeded: (waitSeconds: number) =>
+          this.log(`レート制限の上限に達しました。${waitSeconds}秒待機します...`),
         onRateLimitWait: () => this.log('レート制限を回避するため15秒間待機します...'),
       })
 

--- a/src/commands/issue/base.test.ts
+++ b/src/commands/issue/base.test.ts
@@ -147,3 +147,14 @@ describe('Issueコマンド - 基本機能', () => {
     })
   })
 })
+
+describe('Issueコマンド - 添付ファイルダウンロードフラグ', () => {
+  it('downloadAttachmentsフラグが正しく設定されていること', () => {
+    const {flags} = Issue
+
+    expect(flags.downloadAttachments).to.exist
+    expect(flags.downloadAttachments.required).to.be.false
+    expect(flags.downloadAttachments.char).to.equal('d')
+    expect(flags.downloadAttachments.description).to.include('添付ファイル')
+  })
+})

--- a/src/commands/issue/index.ts
+++ b/src/commands/issue/index.ts
@@ -34,6 +34,9 @@ export default class Issue extends Command {
     `<%= config.bin %> <%= command.id %> --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --issueKeyFileName --issueKeyFolder
 課題キーでフォルダを作成し、ファイル名も課題キーにする
 `,
+    `<%= config.bin %> <%= command.id %> --domain example.backlog.jp --projectIdOrKey PROJECT_KEY --apiKey YOUR_API_KEY --downloadAttachments
+課題の添付ファイルもダウンロードする
+`,
   ]
   static flags = {
     apiKey: Flags.string({
@@ -43,6 +46,11 @@ export default class Issue extends Command {
     domain: Flags.string({
       description: 'Backlog domain (e.g. example.backlog.jp)',
       required: true,
+    }),
+    downloadAttachments: Flags.boolean({
+      char: 'd',
+      description: '課題の添付ファイルもダウンロードする',
+      required: false,
     }),
     issueKeyFileName: Flags.boolean({
       description: 'ファイル名を課題キーにする',
@@ -77,7 +85,7 @@ export default class Issue extends Command {
     const {flags} = await this.parse(Issue)
 
     try {
-      const {domain, issueKeyFileName, issueKeyFolder, maxCount, projectIdOrKey, statusId} = flags
+      const {domain, downloadAttachments, issueKeyFileName, issueKeyFolder, maxCount, projectIdOrKey, statusId} = flags
       const apiKey =
         resolveApiKey(flags.apiKey, () => this.log('環境変数 BACKLOG_API_KEY からAPIキーを使用します')) ??
         this.error(API_KEY_NOT_FOUND_MESSAGE)
@@ -87,6 +95,8 @@ export default class Issue extends Command {
       const {issueRepository, projectRepository} = createBacklogRepositories({
         apiKey,
         domain,
+        onRateLimitExceeded: (waitSeconds: number) =>
+          this.log(`レート制限の上限に達しました。${waitSeconds}秒待機します...`),
         onRateLimitWait: () => this.log('レート制限を回避するため15秒間待機します...'),
       })
 
@@ -101,6 +111,7 @@ export default class Issue extends Command {
       await updateSettings(outputDir, {
         apiKey,
         domain,
+        downloadAttachments,
         folderType: FolderType.ISSUE,
         issueKeyFileName,
         issueKeyFolder,
@@ -114,6 +125,7 @@ export default class Issue extends Command {
         {
           count: maxCount,
           domain,
+          downloadAttachments,
           issueKeyFileName,
           issueKeyFolder,
           outputDir,

--- a/src/commands/update/base.test.ts
+++ b/src/commands/update/base.test.ts
@@ -135,3 +135,14 @@ describe('Updateコマンド - 基本機能', () => {
     })
   })
 })
+
+describe('Updateコマンド - 添付ファイルダウンロードフラグ', () => {
+  it('downloadAttachmentsフラグが正しく設定されていること', () => {
+    const {flags} = Update
+
+    expect(flags.downloadAttachments).to.exist
+    expect(flags.downloadAttachments.required).to.be.false
+    expect(flags.downloadAttachments.char).to.equal('d')
+    expect(flags.downloadAttachments.description).to.include('添付ファイル')
+  })
+})

--- a/src/commands/update/index.ts
+++ b/src/commands/update/index.ts
@@ -65,6 +65,11 @@ export default class Update extends Command {
       description: 'Backlog domain (e.g. example.backlog.jp)',
       required: false,
     }),
+    downloadAttachments: Flags.boolean({
+      char: 'd',
+      description: '課題の添付ファイルもダウンロードする（未指定時は設定ファイルの値を使用）',
+      required: false,
+    }),
     force: Flags.boolean({
       char: 'f',
       description: '確認プロンプトをスキップする',

--- a/src/commands/wiki/index.ts
+++ b/src/commands/wiki/index.ts
@@ -54,6 +54,8 @@ Wikiをダウンロードする
       const {wikiRepository} = createBacklogRepositories({
         apiKey,
         domain,
+        onRateLimitExceeded: (waitSeconds: number) =>
+          this.log(`レート制限の上限に達しました。${waitSeconds}秒待機します...`),
         onRateLimitWait: () => this.log('レート制限を回避するため15秒間待機します...'),
       })
 

--- a/src/composition/backlog-repositories.ts
+++ b/src/composition/backlog-repositories.ts
@@ -11,6 +11,7 @@ import {BacklogHttpClient} from '../shared/backlog/http-client.js'
 export interface BacklogConnection {
   apiKey: string
   domain: string
+  onRateLimitExceeded?: (waitSeconds: number) => void
   onRateLimitWait?: () => void
 }
 

--- a/src/modules/all/use-case/export-all.ts
+++ b/src/modules/all/use-case/export-all.ts
@@ -25,6 +25,7 @@ export type ExportTarget = 'documents' | 'issues' | 'wiki'
 export interface ExportAllOptions {
   apiKey: string
   domain: string
+  downloadAttachments?: boolean
   issueKeyFileName?: boolean
   issueKeyFolder?: boolean
   maxCount: number
@@ -35,7 +36,8 @@ export interface ExportAllOptions {
 
 export async function exportAll(deps: ExportAllDeps, options: ExportAllOptions): Promise<void> {
   const {documentRepository, issueRepository, logger, projectRepository, wikiRepository} = deps
-  const {apiKey, domain, issueKeyFileName, issueKeyFolder, maxCount, outputRoot, projectIdOrKey, targets} = options
+  const {apiKey, domain, downloadAttachments, issueKeyFileName, issueKeyFolder, maxCount, outputRoot, projectIdOrKey, targets} =
+    options
 
   await ensureDirectory(outputRoot)
 
@@ -49,6 +51,7 @@ export async function exportAll(deps: ExportAllDeps, options: ExportAllOptions):
     await updateSettings(issueOutput, {
       apiKey,
       domain,
+      downloadAttachments,
       folderType: FolderType.ISSUE,
       issueKeyFileName,
       issueKeyFolder,
@@ -62,6 +65,7 @@ export async function exportAll(deps: ExportAllDeps, options: ExportAllOptions):
       {
         count: maxCount,
         domain,
+        downloadAttachments,
         issueKeyFileName,
         issueKeyFolder,
         outputDir: issueOutput,

--- a/src/modules/issue/domain/issue-markdown.test.ts
+++ b/src/modules/issue/domain/issue-markdown.test.ts
@@ -1,8 +1,71 @@
 import {describe, expect, it} from 'vitest'
 
-import {buildCommentsSection, createCustomFieldsSection} from './issue-markdown.js'
+import {buildCommentsSection, createCustomFieldsSection, rewriteInlineImages} from './issue-markdown.js'
 
 describe('issue-markdown', () => {
+  describe('rewriteInlineImages', () => {
+    const attachments = [
+      {id: 10, name: 'design.png', size: 100},
+      {id: 11, name: 'スクリーンショット 2026-06-18 12.37.25.png', size: 200},
+    ]
+    const links = new Map([
+      [10, './attachments/TEST-1/10_design.png'],
+      [11, './attachments/TEST-1/11_スクリーンショット_2026-06-18_12.37.25.png'],
+    ])
+
+    it('Markdown拡張記法 ![image][ファイル名] をローカルリンクに変換すること', () => {
+      const result = rewriteInlineImages('前文\n![image][design.png]\n後文', attachments, links)
+      expect(result).to.equal('前文\n![design.png](./attachments/TEST-1/10_design.png)\n後文')
+    })
+
+    it('スペース入り日本語ファイル名も変換すること', () => {
+      const result = rewriteInlineImages('![image][スクリーンショット 2026-06-18 12.37.25.png]', attachments, links)
+      expect(result).to.equal(
+        '![スクリーンショット 2026-06-18 12.37.25.png](./attachments/TEST-1/11_スクリーンショット_2026-06-18_12.37.25.png)',
+      )
+    })
+
+    it('Backlog記法 #image(ファイル名) をローカルリンクに変換すること', () => {
+      const result = rewriteInlineImages('#image(design.png)', attachments, links)
+      expect(result).to.equal('![design.png](./attachments/TEST-1/10_design.png)')
+    })
+
+    it('添付一覧にないファイル名の参照はそのまま残すこと', () => {
+      const text = '![image][unknown.png] と #image(other.png)'
+      expect(rewriteInlineImages(text, attachments, links)).to.equal(text)
+    })
+
+    it('ダウンロードされていない添付への参照はそのまま残すこと', () => {
+      const text = '![image][design.png]'
+      expect(rewriteInlineImages(text, attachments, new Map())).to.equal(text)
+      expect(rewriteInlineImages(text, attachments)).to.equal(text)
+    })
+
+    it('NFD（結合濁点）の参照名をNFCの添付名と照合できること', () => {
+      const nfdName = 'ドリンク.png'.normalize('NFD')
+      const result = rewriteInlineImages(
+        `![image][${nfdName}]`,
+        [{id: 20, name: 'ドリンク.png'.normalize('NFC'), size: 10}],
+        new Map([[20, './attachments/TEST-1/20_ドリンク.png']]),
+      )
+      expect(result).to.equal(`![${nfdName}](./attachments/TEST-1/20_ドリンク.png)`)
+    })
+
+    it('ファイル名中の角括弧をエスケープすること', () => {
+      const result = rewriteInlineImages(
+        '#image(x]y.png)',
+        [{id: 30, name: 'x]y.png', size: 10}],
+        new Map([[30, './attachments/TEST-1/30_x_y.png']]),
+      )
+      expect(result).to.equal(String.raw`![x\]y.png](./attachments/TEST-1/30_x_y.png)`)
+    })
+
+    it('通常の参照リンク（添付名と一致しないラベル）を壊さないこと', () => {
+      const text = '![alt text][ref1]\n\n[ref1]: https://example.com/a.png'
+      expect(rewriteInlineImages(text, attachments, links)).to.equal(text)
+    })
+  })
+
   describe('createCustomFieldsSection', () => {
     it('空の配列の場合は空文字列を返すこと', () => {
       const result = createCustomFieldsSection([])

--- a/src/modules/issue/domain/issue-markdown.ts
+++ b/src/modules/issue/domain/issue-markdown.ts
@@ -1,5 +1,5 @@
 import {wrapBody} from '../../../shared/markdown/body-marker.js'
-import {CustomField, Issue, IssueComment, IssueCommentChange} from './issue.js'
+import {CustomField, Issue, IssueAttachment, IssueComment, IssueCommentChange} from './issue.js'
 
 // Backlogの変更履歴（changeLog）のfieldを画面表示に合わせた日本語ラベルへ変換する
 const CHANGE_FIELD_LABELS: Record<string, string> = {
@@ -35,11 +35,43 @@ function formatChange(change: IssueCommentChange): string {
   return `- ${label}: ${formatChangeValue(change.originalValue)} → ${formatChangeValue(change.newValue)}`
 }
 
-function buildCommentBody(comment: IssueComment): string {
+// Backlogの添付画像インライン記法（Markdown拡張の ![alt][ファイル名] とBacklog記法の #image(ファイル名)）を
+// ダウンロード済みファイルへのローカルリンクに変換する。未ダウンロードの参照は壊さずそのまま残す
+export function rewriteInlineImages(
+  text: string,
+  attachments: IssueAttachment[] | undefined,
+  localLinks?: Map<number, string>,
+): string {
+  if (!text || !attachments || attachments.length === 0 || !localLinks || localLinks.size === 0) {
+    return text
+  }
+
+  // 同名添付が複数ある場合は記法から特定できないため先勝ちで解決する。
+  // 記法内のファイル名はNFD（macOSからのD&D等）で入ることがあるため、照合はNFC正規化で行う
+  const linkByName = new Map<string, string>()
+  for (const attachment of attachments) {
+    const link = localLinks.get(attachment.id)
+    const name = attachment.name.normalize('NFC')
+    if (link && !linkByName.has(name)) {
+      linkByName.set(name, link)
+    }
+  }
+
+  const toLocalImage = (match: string, name: string) => {
+    const link = linkByName.get(name.normalize('NFC'))
+    return link ? `![${escapeLinkText(name)}](${link})` : match
+  }
+
+  return text
+    .replaceAll(/!\[[^\]]*\]\[([^\]]+)\]/g, toLocalImage)
+    .replaceAll(/#image\(([^)]+)\)/g, toLocalImage)
+}
+
+function buildCommentBody(comment: IssueComment, rewriteBody: (text: string) => string): string {
   const parts: string[] = []
 
   if (comment.content) {
-    parts.push(comment.content)
+    parts.push(rewriteBody(comment.content))
   }
 
   if (comment.changeLog && comment.changeLog.length > 0) {
@@ -83,7 +115,34 @@ export function createCustomFieldsSection(customFields?: CustomField[]): string 
   return customFieldsSection
 }
 
-export function buildCommentsSection(comments: IssueComment[], backlogIssueUrl: string): string {
+// ファイル名中の角括弧はリンク構文を壊すためエスケープする
+function escapeLinkText(name: string): string {
+  return name.replaceAll('[', String.raw`\[`).replaceAll(']', String.raw`\]`)
+}
+
+// ダウンロード済みの添付はローカルへの相対リンク付き、未ダウンロードはメタデータのみを出力する
+export function buildAttachmentsSection(
+  attachments: IssueAttachment[] | undefined,
+  localLinks?: Map<number, string>,
+): string {
+  if (!attachments || attachments.length === 0) {
+    return ''
+  }
+
+  const lines = attachments.map((attachment) => {
+    const fileSize = `${(attachment.size / 1024).toFixed(1)} KB`
+    const link = localLinks?.get(attachment.id)
+    return link ? `- [${escapeLinkText(attachment.name)}](${link}) (${fileSize})` : `- ${attachment.name} (${fileSize})`
+  })
+
+  return `\n\n## 添付ファイル\n\n${lines.join('\n')}`
+}
+
+export function buildCommentsSection(
+  comments: IssueComment[],
+  backlogIssueUrl: string,
+  rewriteBody: (text: string) => string = (text) => text,
+): string {
   if (comments.length === 0) {
     return ''
   }
@@ -95,7 +154,7 @@ export function buildCommentsSection(comments: IssueComment[], backlogIssueUrl: 
     const backlogCommentUrl = `${backlogIssueUrl}#comment-${comment.id}`
     commentsSection += `\n### コメント ${commentIndex}\n- **投稿者**: ${
       comment.createdUser.name
-    }\n- **日時**: ${commentDate}\n- [Backlog Comment Link](${backlogCommentUrl})\n\n${buildCommentBody(comment)}\n\n---\n`
+    }\n- **日時**: ${commentDate}\n- [Backlog Comment Link](${backlogCommentUrl})\n\n${buildCommentBody(comment, rewriteBody)}\n\n---\n`
     commentIndex++
   }
 
@@ -103,9 +162,16 @@ export function buildCommentsSection(comments: IssueComment[], backlogIssueUrl: 
   return commentsSection.slice(0, -5)
 }
 
-export function buildIssueMarkdown(issue: Issue, comments: IssueComment[], backlogIssueUrl: string): string {
-  const commentsSection = buildCommentsSection(comments, backlogIssueUrl)
+export function buildIssueMarkdown(
+  issue: Issue,
+  comments: IssueComment[],
+  backlogIssueUrl: string,
+  attachmentLinks?: Map<number, string>,
+): string {
+  const rewriteBody = (text: string) => rewriteInlineImages(text, issue.attachments, attachmentLinks)
+  const commentsSection = buildCommentsSection(comments, backlogIssueUrl, rewriteBody)
   const customFieldsSection = createCustomFieldsSection(issue.customFields)
+  const attachmentsSection = buildAttachmentsSection(issue.attachments, attachmentLinks)
 
   const assigneeName = issue.assignee ? issue.assignee.name : '未割り当て'
   const startDate = issue.startDate ? new Date(issue.startDate).toLocaleDateString('ja-JP') : '未設定'
@@ -123,9 +189,9 @@ export function buildIssueMarkdown(issue: Issue, comments: IssueComment[], backl
 - 期限日: ${dueDate}
 - 作成日時: ${new Date(issue.created).toLocaleString('ja-JP')}
 - 更新日時: ${new Date(issue.updated).toLocaleString('ja-JP')}
-- [Backlog Issue Link](${backlogIssueUrl})${customFieldsSection}
+- [Backlog Issue Link](${backlogIssueUrl})${customFieldsSection}${attachmentsSection}
 
 ## 詳細
 
-${wrapBody(issue.description || '詳細情報なし')}${commentsSection}`
+${wrapBody(issue.description ? rewriteBody(issue.description) : '詳細情報なし')}${commentsSection}`
 }

--- a/src/modules/issue/domain/issue-path.ts
+++ b/src/modules/issue/domain/issue-path.ts
@@ -1,9 +1,9 @@
 import path from 'node:path'
 
 import {backlogOrigin} from '../../../shared/backlog-url.js'
-import {sanitizeFileName} from '../../../shared/file-name.js'
+import {sanitizeAttachmentFileName, sanitizeFileName} from '../../../shared/file-name.js'
 import {ExpectedPaths} from '../../prune/domain/expected-paths.js'
-import {Issue} from './issue.js'
+import {Issue, IssueAttachment} from './issue.js'
 
 export function issueFileName(issue: {issueKey: string; summary: string}, useIssueKey: boolean): string {
   return useIssueKey ? `${issue.issueKey}.md` : `${sanitizeFileName(issue.summary)}.md`
@@ -24,6 +24,38 @@ export function issueRelativePath(
   )
 }
 
+// 添付IDを前置して同一課題内の同名添付の衝突を防ぎ、存在チェックだけでDL済み判定できるようにする
+export function attachmentFileName(attachment: Pick<IssueAttachment, 'id' | 'name'>): string {
+  return `${attachment.id}_${sanitizeAttachmentFileName(attachment.name)}`
+}
+
+// issueKeyFolderありなら課題フォルダ直下のattachments/、なしなら年フォルダのattachments/{課題キー}/
+function attachmentDirSegments(issueKey: string, useIssueKeyFolder: boolean): string[] {
+  return useIssueKeyFolder ? ['attachments'] : ['attachments', issueKey]
+}
+
+export function attachmentRelativePath(
+  issue: {created: string; issueKey: string},
+  attachment: Pick<IssueAttachment, 'id' | 'name'>,
+  options: {issueKeyFolder?: boolean},
+): string {
+  return path.join(
+    issueRelativeDir(issue, options.issueKeyFolder ?? false),
+    ...attachmentDirSegments(issue.issueKey, options.issueKeyFolder ?? false),
+    attachmentFileName(attachment),
+  )
+}
+
+// Markdownファイルから添付への相対リンク。丸括弧はインラインリンクを壊すためエンコードする
+export function attachmentMarkdownLink(
+  issue: {issueKey: string},
+  attachment: Pick<IssueAttachment, 'id' | 'name'>,
+  options: {issueKeyFolder?: boolean},
+): string {
+  const segments = attachmentDirSegments(issue.issueKey, options.issueKeyFolder ?? false)
+  return ['.', ...segments, attachmentFileName(attachment)].join('/').replaceAll('(', '%28').replaceAll(')', '%29')
+}
+
 export function issueUrl(domain: string, issueKey: string): string {
   return `${backlogOrigin(domain)}/view/${issueKey}`
 }
@@ -36,13 +68,23 @@ export function buildIssueExpectedPaths(
   const expectedFiles = new Set<string>()
   const expectedDirs = new Set<string>()
 
+  const addDirs = (dir: string) => {
+    let current = dir
+    while (current && current !== '.') {
+      expectedDirs.add(current.normalize('NFC'))
+      current = path.dirname(current)
+    }
+  }
+
   for (const issue of issues) {
     expectedFiles.add(issueRelativePath(issue, options).normalize('NFC'))
+    addDirs(issueRelativeDir(issue, options.issueKeyFolder ?? false))
 
-    let dir = issueRelativeDir(issue, options.issueKeyFolder ?? false)
-    while (dir && dir !== '.') {
-      expectedDirs.add(dir.normalize('NFC'))
-      dir = path.dirname(dir)
+    // .md拡張子の添付ファイルがpruneで誤削除されないよう、添付パスも期待集合に含める
+    for (const attachment of issue.attachments ?? []) {
+      const attachmentPath = attachmentRelativePath(issue, attachment, options)
+      expectedFiles.add(attachmentPath.normalize('NFC'))
+      addDirs(path.dirname(attachmentPath))
     }
   }
 

--- a/src/modules/issue/domain/issue-repository.ts
+++ b/src/modules/issue/domain/issue-repository.ts
@@ -1,6 +1,7 @@
 import {Issue, IssueComment} from './issue.js'
 
 export interface IssueRepository {
+  downloadAttachment(issueIdOrKey: string, attachmentId: number): Promise<ArrayBuffer>
   fetchAllComments(issueKey: string): Promise<IssueComment[]>
   fetchByIdOrKey(issueIdOrKey: string): Promise<Issue>
   fetchPage(options: {count: number; offset: number; projectId: number; statusId?: string}): Promise<Issue[]>

--- a/src/modules/issue/domain/issue.ts
+++ b/src/modules/issue/domain/issue.ts
@@ -1,5 +1,6 @@
 export interface Issue {
   assignee: null | {id: number; name: string}
+  attachments?: IssueAttachment[]
   created: string
   customFields: CustomField[]
   description: string
@@ -12,6 +13,12 @@ export interface Issue {
   status: {id: number; name: string}
   summary: string
   updated: string
+}
+
+export interface IssueAttachment {
+  id: number
+  name: string
+  size: number
 }
 
 export interface CustomField {

--- a/src/modules/issue/repository/backlog-issue-repository.ts
+++ b/src/modules/issue/repository/backlog-issue-repository.ts
@@ -4,6 +4,10 @@ import {Issue, IssueComment} from '../domain/issue.js'
 
 export function newBacklogIssueRepository(client: BacklogHttpClient): IssueRepository {
   return {
+    async downloadAttachment(issueIdOrKey, attachmentId) {
+      return client.getBinary(`/issues/${issueIdOrKey}/attachments/${attachmentId}`)
+    },
+
     async fetchAllComments(issueKey) {
       const allComments: IssueComment[] = []
       let minId: number | undefined

--- a/src/modules/issue/use-case/export-issues.test.ts
+++ b/src/modules/issue/use-case/export-issues.test.ts
@@ -126,6 +126,211 @@ describe('exportIssues', () => {
     expect(server.requestedPaths()).to.not.include('/api/v2/issues')
   })
 
+  it('downloadAttachments指定時に添付ファイルを保存し、Markdownにローカルリンクを記載すること', async () => {
+    const binary = new Uint8Array([1, 2, 3, 4])
+    server.respond('/api/v2/issues', {
+      body: [issue({attachments: [{id: 10, name: 'design.png', size: 2048}]})],
+    })
+    server.respond('/api/v2/issues/TEST-1/comments', {body: []})
+    server.respond('/api/v2/issues/TEST-1/attachments/10', {body: binary})
+
+    await exportIssues(
+      {issueRepository: newBacklogIssueRepository(client()), logger: stubLogger},
+      {
+        domain: server.domain,
+        downloadAttachments: true,
+        outputDir,
+        projectId: PROJECT_ID,
+      },
+    )
+
+    const saved = await fs.readFile(join(outputDir, '2026', 'attachments', 'TEST-1', '10_design.png'))
+    expect(new Uint8Array(saved)).to.deep.equal(binary)
+
+    const content = await fs.readFile(join(outputDir, '2026', 'テスト課題.md'), 'utf8')
+    expect(content).to.include('## 添付ファイル')
+    expect(content).to.include('- [design.png](./attachments/TEST-1/10_design.png) (2.0 KB)')
+  })
+
+  it('issueKeyFolder指定時は課題フォルダ直下のattachmentsに保存すること', async () => {
+    server.respond('/api/v2/issues', {
+      body: [issue({attachments: [{id: 11, name: 'log.txt', size: 512}]})],
+    })
+    server.respond('/api/v2/issues/TEST-1/comments', {body: []})
+    server.respond('/api/v2/issues/TEST-1/attachments/11', {body: new Uint8Array([5, 6])})
+
+    await exportIssues(
+      {issueRepository: newBacklogIssueRepository(client()), logger: stubLogger},
+      {
+        domain: server.domain,
+        downloadAttachments: true,
+        issueKeyFolder: true,
+        outputDir,
+        projectId: PROJECT_ID,
+      },
+    )
+
+    await fs.access(join(outputDir, '2026', 'TEST-1', 'attachments', '11_log.txt'))
+
+    const content = await fs.readFile(join(outputDir, '2026', 'TEST-1', 'テスト課題.md'), 'utf8')
+    expect(content).to.include('- [log.txt](./attachments/11_log.txt) (0.5 KB)')
+  })
+
+  it('本文とコメント内の添付画像記法をローカルリンクに変換すること', async () => {
+    server.respond('/api/v2/issues', {
+      body: [
+        issue({
+          attachments: [{id: 10, name: 'design.png', size: 2048}],
+          description: '説明\n![image][design.png]',
+        }),
+      ],
+    })
+    server.respond('/api/v2/issues/TEST-1/comments', {
+      body: [
+        {
+          content: 'コメント画像\n#image(design.png)',
+          created: '2026-01-02T10:00:00Z',
+          createdUser: {id: 1, name: '投稿者'},
+          id: 999,
+        },
+      ],
+    })
+    server.respond('/api/v2/issues/TEST-1/attachments/10', {body: new Uint8Array([1])})
+
+    await exportIssues(
+      {issueRepository: newBacklogIssueRepository(client()), logger: stubLogger},
+      {
+        domain: server.domain,
+        downloadAttachments: true,
+        outputDir,
+        projectId: PROJECT_ID,
+      },
+    )
+
+    const content = await fs.readFile(join(outputDir, '2026', 'テスト課題.md'), 'utf8')
+    expect(content).to.include('説明\n![design.png](./attachments/TEST-1/10_design.png)')
+    expect(content).to.include('コメント画像\n![design.png](./attachments/TEST-1/10_design.png)')
+    expect(content).to.not.include('![image][design.png]')
+  })
+
+  it('downloadAttachments未指定時は画像記法を変換しないこと', async () => {
+    server.respond('/api/v2/issues', {
+      body: [
+        issue({
+          attachments: [{id: 10, name: 'design.png', size: 2048}],
+          description: '![image][design.png]',
+        }),
+      ],
+    })
+    server.respond('/api/v2/issues/TEST-1/comments', {body: []})
+
+    await exportIssues(
+      {issueRepository: newBacklogIssueRepository(client()), logger: stubLogger},
+      {
+        domain: server.domain,
+        outputDir,
+        projectId: PROJECT_ID,
+      },
+    )
+
+    const content = await fs.readFile(join(outputDir, '2026', 'テスト課題.md'), 'utf8')
+    expect(content).to.include('![image][design.png]')
+  })
+
+  it('ダウンロード済みの添付ファイルは再ダウンロードしないこと', async () => {
+    server.respond('/api/v2/issues', {
+      body: [issue({attachments: [{id: 10, name: 'design.png', size: 2}]})],
+    })
+    server.respond('/api/v2/issues/TEST-1/comments', {body: []})
+
+    const existingPath = join(outputDir, '2026', 'attachments', 'TEST-1', '10_design.png')
+    await fs.mkdir(join(outputDir, '2026', 'attachments', 'TEST-1'), {recursive: true})
+    await fs.writeFile(existingPath, new Uint8Array([9, 9]))
+
+    await exportIssues(
+      {issueRepository: newBacklogIssueRepository(client()), logger: stubLogger},
+      {
+        domain: server.domain,
+        downloadAttachments: true,
+        outputDir,
+        projectId: PROJECT_ID,
+      },
+    )
+
+    expect(server.requestedPaths()).to.not.include('/api/v2/issues/TEST-1/attachments/10')
+    const content = await fs.readFile(join(outputDir, '2026', 'テスト課題.md'), 'utf8')
+    expect(content, 'スキップした添付にもリンクが付くこと').to.include('(./attachments/TEST-1/10_design.png)')
+  })
+
+  it('サイズの一致しない既存ファイル（破損）は再ダウンロードすること', async () => {
+    const binary = new Uint8Array([1, 2, 3, 4])
+    server.respond('/api/v2/issues', {
+      body: [issue({attachments: [{id: 10, name: 'design.png', size: 4}]})],
+    })
+    server.respond('/api/v2/issues/TEST-1/comments', {body: []})
+    server.respond('/api/v2/issues/TEST-1/attachments/10', {body: binary})
+
+    const existingPath = join(outputDir, '2026', 'attachments', 'TEST-1', '10_design.png')
+    await fs.mkdir(join(outputDir, '2026', 'attachments', 'TEST-1'), {recursive: true})
+    await fs.writeFile(existingPath, new Uint8Array([9]))
+
+    await exportIssues(
+      {issueRepository: newBacklogIssueRepository(client()), logger: stubLogger},
+      {
+        domain: server.domain,
+        downloadAttachments: true,
+        outputDir,
+        projectId: PROJECT_ID,
+      },
+    )
+
+    expect(server.requestedPaths()).to.include('/api/v2/issues/TEST-1/attachments/10')
+    const saved = await fs.readFile(existingPath)
+    expect(new Uint8Array(saved)).to.deep.equal(binary)
+  })
+
+  it('添付ファイルの取得に失敗しても課題本体は保存し、リンクなしで記載すること', async () => {
+    server.respond('/api/v2/issues', {
+      body: [issue({attachments: [{id: 12, name: 'broken.pdf', size: 1024}]})],
+    })
+    server.respond('/api/v2/issues/TEST-1/comments', {body: []})
+    server.respond('/api/v2/issues/TEST-1/attachments/12', {status: 404})
+
+    await exportIssues(
+      {issueRepository: newBacklogIssueRepository(client()), logger: stubLogger},
+      {
+        domain: server.domain,
+        downloadAttachments: true,
+        outputDir,
+        projectId: PROJECT_ID,
+      },
+    )
+
+    const content = await fs.readFile(join(outputDir, '2026', 'テスト課題.md'), 'utf8')
+    expect(content).to.include('- broken.pdf (1.0 KB)')
+    expect(content).to.not.include('](./attachments')
+  })
+
+  it('downloadAttachments未指定時はダウンロードせず、メタデータのみ記載すること', async () => {
+    server.respond('/api/v2/issues', {
+      body: [issue({attachments: [{id: 10, name: 'design.png', size: 2048}]})],
+    })
+    server.respond('/api/v2/issues/TEST-1/comments', {body: []})
+
+    await exportIssues(
+      {issueRepository: newBacklogIssueRepository(client()), logger: stubLogger},
+      {
+        domain: server.domain,
+        outputDir,
+        projectId: PROJECT_ID,
+      },
+    )
+
+    expect(server.requestedPaths()).to.not.include('/api/v2/issues/TEST-1/attachments/10')
+    const content = await fs.readFile(join(outputDir, '2026', 'テスト課題.md'), 'utf8')
+    expect(content).to.include('- design.png (2.0 KB)')
+  })
+
   it('projectId[]パラメータ付きで課題一覧を取得すること', async () => {
     server.respond('/api/v2/issues', {body: []})
 

--- a/src/modules/issue/use-case/export-issues.ts
+++ b/src/modules/issue/use-case/export-issues.ts
@@ -2,11 +2,11 @@ import path from 'node:path'
 
 import {writeProgress} from '../../../shared/console/progress.js'
 import {Logger} from '../../../shared/ports.js'
-import {writeMarkdownFile} from '../../../shared/storage/markdown-store.js'
+import {fileSize, writeBinaryFile, writeMarkdownFile} from '../../../shared/storage/markdown-store.js'
 import {appendLog} from '../../../shared/storage/update-log.js'
 import {filterIssuesUpdatedSince} from '../domain/issue-filter.js'
 import {buildIssueMarkdown} from '../domain/issue-markdown.js'
-import {issueRelativePath, issueUrl} from '../domain/issue-path.js'
+import {attachmentMarkdownLink, attachmentRelativePath, issueRelativePath, issueUrl} from '../domain/issue-path.js'
 import {IssueRepository} from '../domain/issue-repository.js'
 import {Issue, IssueComment} from '../domain/issue.js'
 
@@ -18,6 +18,7 @@ export interface ExportIssuesDeps {
 export interface ExportIssuesOptions {
   count?: number
   domain: string
+  downloadAttachments?: boolean
   issueIdOrKeys?: string[]
   issueKeyFileName?: boolean
   issueKeyFolder?: boolean
@@ -122,7 +123,45 @@ async function saveIssue(deps: ExportIssuesDeps, issue: Issue, options: ExportIs
     )
   }
 
+  const attachmentLinks = options.downloadAttachments
+    ? await downloadIssueAttachments(deps, issue, options)
+    : undefined
+
   const filePath = path.join(options.outputDir, issueRelativePath(issue, options))
-  await writeMarkdownFile(filePath, buildIssueMarkdown(issue, comments, backlogIssueUrl))
+  await writeMarkdownFile(filePath, buildIssueMarkdown(issue, comments, backlogIssueUrl, attachmentLinks))
   await appendLog(options.outputDir, `課題「${issue.summary}」を更新しました: ${backlogIssueUrl}`)
+}
+
+// 保存できた添付のみリンク化する。個々の失敗は警告に留め、課題本体の保存は続行する
+async function downloadIssueAttachments(
+  deps: ExportIssuesDeps,
+  issue: Issue,
+  options: ExportIssuesOptions,
+): Promise<Map<number, string>> {
+  const links = new Map<number, string>()
+
+  for (const attachment of issue.attachments ?? []) {
+    const absolutePath = path.join(options.outputDir, attachmentRelativePath(issue, attachment, options))
+    try {
+      // 添付IDは不変のため、サイズの一致するファイルが既にあれば再ダウンロードしない
+      // （サイズ不一致は過去の中断等による破損とみなして取得し直す）
+      // eslint-disable-next-line no-await-in-loop
+      if ((await fileSize(absolutePath)) !== attachment.size) {
+        // eslint-disable-next-line no-await-in-loop
+        const data = await deps.issueRepository.downloadAttachment(issue.issueKey, attachment.id)
+        // eslint-disable-next-line no-await-in-loop
+        await writeBinaryFile(absolutePath, data)
+      }
+
+      links.set(attachment.id, attachmentMarkdownLink(issue, attachment, options))
+    } catch (error) {
+      deps.logger.warn(
+        `課題 ${issue.issueKey} の添付ファイル「${attachment.name}」の取得に失敗しました: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      )
+    }
+  }
+
+  return links
 }

--- a/src/modules/prune/use-case/prune-directories.ts
+++ b/src/modules/prune/use-case/prune-directories.ts
@@ -17,7 +17,12 @@ export interface PruneFlags {
 
 export interface PruneDeps {
   // ディレクトリごとに設定ファイルから接続情報が決まるため、repositoryはファクトリで注入する
-  createRepositories: (connection: {apiKey: string; domain: string; onRateLimitWait?: () => void}) => {
+  createRepositories: (connection: {
+    apiKey: string
+    domain: string
+    onRateLimitExceeded?: (waitSeconds: number) => void
+    onRateLimitWait?: () => void
+  }) => {
     documentRepository: DocumentRepository
     issueRepository: IssueRepository
     projectRepository: ProjectRepository
@@ -106,6 +111,7 @@ async function pruneDirectory(
   const {documentRepository, issueRepository, projectRepository, wikiRepository} = deps.createRepositories({
     apiKey,
     domain,
+    onRateLimitExceeded: (waitSeconds: number) => logger.log(`レート制限の上限に達しました。${waitSeconds}秒待機します...`),
     onRateLimitWait: () => logger.log('レート制限を回避するため15秒間待機します...'),
   })
 

--- a/src/modules/prune/use-case/prune-exports.test.ts
+++ b/src/modules/prune/use-case/prune-exports.test.ts
@@ -335,6 +335,21 @@ describe('pruneIssues（不要なローカル課題ファイルの削除）', ()
     expect(existsSync(join(outputDir, '2026', 'TEST-9')), '空になった課題キーフォルダは削除されること').to.be.false
   })
 
+  it('ダウンロード済みの.md拡張子の添付ファイルは削除しないこと', async () => {
+    server.respond('/api/v2/issues', {
+      body: [{...issue('TEST-1', '添付つき課題'), attachments: [{id: 10, name: 'notes.md', size: 100}]}],
+    })
+
+    await fs.mkdir(join(outputDir, '2026', 'attachments', 'TEST-1'), {recursive: true})
+    await fs.writeFile(join(outputDir, '2026', '添付つき課題.md'), '# 添付つき課題')
+    await fs.writeFile(join(outputDir, '2026', 'attachments', 'TEST-1', '10_notes.md'), '# 添付本体')
+
+    const pruned = await pruneIssues(issuePruneDeps(), {outputDir, projectId: PROJECT_ID})
+
+    expect(pruned).to.equal(0)
+    expect(existsSync(join(outputDir, '2026', 'attachments', 'TEST-1', '10_notes.md'))).to.be.true
+  })
+
   it('課題が100件を超える場合はページングで全件を取得すること', async () => {
     server.respond('/api/v2/issues', (url) => {
       const offset = Number(url.searchParams.get('offset'))

--- a/src/modules/settings/domain/settings.ts
+++ b/src/modules/settings/domain/settings.ts
@@ -7,6 +7,7 @@ export enum FolderType {
 export interface Settings {
   apiKey?: string
   domain?: string
+  downloadAttachments?: boolean
   folderType?: FolderType
   issueKeyFileName?: boolean
   issueKeyFolder?: boolean

--- a/src/modules/update/domain/update-plan.test.ts
+++ b/src/modules/update/domain/update-plan.test.ts
@@ -1,0 +1,20 @@
+import {describe, expect, it} from 'vitest'
+
+import {buildUpdatePlan} from './update-plan.js'
+
+describe('buildUpdatePlan - downloadAttachmentsの解決', () => {
+  it('フラグ指定が設定ファイルより優先されること', () => {
+    const plan = buildUpdatePlan({downloadAttachments: false}, {downloadAttachments: true})
+    expect(plan.downloadAttachments).to.be.true
+  })
+
+  it('フラグ未指定時は設定ファイルの値を引き継ぐこと', () => {
+    const plan = buildUpdatePlan({downloadAttachments: true}, {})
+    expect(plan.downloadAttachments).to.be.true
+  })
+
+  it('フラグも設定もない場合はfalseになること', () => {
+    const plan = buildUpdatePlan({}, {})
+    expect(plan.downloadAttachments).to.be.false
+  })
+})

--- a/src/modules/update/domain/update-plan.ts
+++ b/src/modules/update/domain/update-plan.ts
@@ -5,6 +5,7 @@ export interface UpdateFlags {
   documentId?: string
   documentsOnly?: boolean
   domain?: string
+  downloadAttachments?: boolean
   force?: boolean
   issueIdOrKey?: string
   issueKeyFileName?: boolean
@@ -18,6 +19,7 @@ export interface UpdateFlags {
 export interface UpdatePlan {
   documentIds?: string[]
   domain?: string
+  downloadAttachments: boolean
   folderType?: FolderType
   issueIdOrKeys?: string[]
   issueKeyFileName: boolean
@@ -101,6 +103,7 @@ export function buildUpdatePlan(settings: Settings, flags: UpdateFlags): UpdateP
     documentIds,
     // コマンドライン引数と設定ファイルを組み合わせて使用する値を決定
     domain: flags.domain || settings.domain,
+    downloadAttachments: flags.downloadAttachments ?? settings.downloadAttachments ?? false,
     folderType: settings.folderType,
     issueIdOrKeys,
     // 設定ファイルからオプションを読み込み、コマンドライン引数で上書き

--- a/src/modules/update/use-case/update-exports.ts
+++ b/src/modules/update/use-case/update-exports.ts
@@ -17,7 +17,12 @@ export type {UpdateFlags} from '../domain/update-plan.js'
 
 export interface UpdateDeps {
   // ディレクトリごとに設定ファイルから接続情報が決まるため、repositoryはファクトリで注入する
-  createRepositories: (connection: {apiKey: string; domain: string; onRateLimitWait?: () => void}) => {
+  createRepositories: (connection: {
+    apiKey: string
+    domain: string
+    onRateLimitExceeded?: (waitSeconds: number) => void
+    onRateLimitWait?: () => void
+  }) => {
     documentRepository: DocumentRepository
     issueRepository: IssueRepository
     projectRepository: ProjectRepository
@@ -80,6 +85,7 @@ async function updateDirectory(deps: UpdateDeps, targetDir: string, flags: Updat
   const {documentRepository, issueRepository, projectRepository, wikiRepository} = deps.createRepositories({
     apiKey,
     domain: plan.domain,
+    onRateLimitExceeded: (waitSeconds: number) => logger.log(`レート制限の上限に達しました。${waitSeconds}秒待機します...`),
     onRateLimitWait: () => logger.log('レート制限を回避するため15秒間待機します...'),
   })
 
@@ -103,6 +109,7 @@ async function updateDirectory(deps: UpdateDeps, targetDir: string, flags: Updat
       {
         count: 100,
         domain: plan.domain,
+        downloadAttachments: plan.downloadAttachments,
         issueIdOrKeys: plan.issueIdOrKeys,
         issueKeyFileName: plan.issueKeyFileName,
         issueKeyFolder: plan.issueKeyFolder,

--- a/src/shared/backlog/http-client.test.ts
+++ b/src/shared/backlog/http-client.test.ts
@@ -1,9 +1,30 @@
 import {afterAll, beforeAll, beforeEach, describe, expect, it} from 'vitest'
 
 import {BacklogMockServer} from '../testing/backlog-mock-server.js'
-import {BacklogHttpClient, HttpError} from './http-client.js'
+import {BacklogHttpClient, HttpError, rateLimitWaitMs} from './http-client.js'
 
 const API_KEY = 'test-api-key'
+
+describe('rateLimitWaitMs', () => {
+  it('リセット時刻までの残り時間+1秒を返すこと', () => {
+    const nowMs = 1_700_000_000_000
+    expect(rateLimitWaitMs(String(1_700_000_030), nowMs)).to.equal(31_000)
+  })
+
+  it('ヘッダーが無い場合は1分を返すこと', () => {
+    expect(rateLimitWaitMs(null, 0)).to.equal(60_000)
+    expect(rateLimitWaitMs('invalid', 0)).to.equal(60_000)
+  })
+
+  it('過去のリセット時刻は最小1秒に丸めること', () => {
+    expect(rateLimitWaitMs('1000', 1_700_000_000_000)).to.equal(1000)
+  })
+
+  it('異常に先のリセット時刻は最大2分に丸めること', () => {
+    const nowMs = 1_700_000_000_000
+    expect(rateLimitWaitMs(String(1_700_000_000 + 600), nowMs)).to.equal(120_000)
+  })
+})
 
 describe('BacklogHttpClient', () => {
   const server = new BacklogMockServer()
@@ -59,6 +80,37 @@ describe('BacklogHttpClient', () => {
     }
 
     expect(server.requests).to.have.length(1)
+  })
+
+  it('バイナリデータを取得できること', async () => {
+    const binary = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
+    server.respond('/api/v2/issues/TEST-1/attachments/1', {body: binary})
+
+    const result = await client().getBinary('/issues/TEST-1/attachments/1')
+
+    expect(new Uint8Array(result)).to.deep.equal(binary)
+    expect(server.requests[0].searchParams.get('apiKey')).to.equal(API_KEY)
+  })
+
+  it('429はX-RateLimit-Resetまで待機してからリトライし、待機を通知すること', async () => {
+    // リセット時刻が過去のため最小待機(1秒)でリトライされる
+    server.respondOnce('/api/v2/projects/TEST', {
+      headers: {'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) - 10)},
+      status: 429,
+    })
+    server.respond('/api/v2/projects/TEST', {body: {id: 1}})
+
+    const notifiedWaits: number[] = []
+    const notifyingClient = new BacklogHttpClient({
+      apiKey: API_KEY,
+      domain: server.domain,
+      onRateLimitExceeded: (waitSeconds) => notifiedWaits.push(waitSeconds),
+    })
+    const result = await notifyingClient.getJson<{id: number}>('/projects/TEST')
+
+    expect(result).to.deep.equal({id: 1})
+    expect(server.requests).to.have.length(2)
+    expect(notifiedWaits).to.deep.equal([1])
   })
 
   it('エラーメッセージのURL中のapiKeyがマスクされること', async () => {

--- a/src/shared/backlog/http-client.ts
+++ b/src/shared/backlog/http-client.ts
@@ -16,25 +16,50 @@ export class HttpError extends Error {
 const RETRYABLE_STATUSES = new Set([408, 429, 500, 502, 503, 504])
 const MAX_RETRIES = 2
 const RETRY_BASE_DELAY_MS = 300
+const RATE_LIMIT_MIN_WAIT_MS = 1000
+const RATE_LIMIT_FALLBACK_WAIT_MS = 60_000
+const RATE_LIMIT_MAX_WAIT_MS = 120_000
+
+// レート制限(429)はウィンドウが1分単位のため、短いbackoffではなく
+// X-RateLimit-Reset(UNIX秒)まで待つ。ヘッダーが無い/不正な場合は1分待つ
+export function rateLimitWaitMs(resetHeader: null | string, nowMs: number): number {
+  const resetSeconds = Number(resetHeader)
+  if (!resetHeader || !Number.isFinite(resetSeconds)) return RATE_LIMIT_FALLBACK_WAIT_MS
+  // リセット直後の境界ずれで再度429にならないよう1秒の余裕を持たせる
+  const waitMs = resetSeconds * 1000 - nowMs + 1000
+  return Math.min(Math.max(waitMs, RATE_LIMIT_MIN_WAIT_MS), RATE_LIMIT_MAX_WAIT_MS)
+}
 
 // apiKey付与・レート制限(100req/15s)・一時エラーのリトライを担うBacklog APIクライアント
 export class BacklogHttpClient {
   private readonly apiKey: string
   private readonly baseUrl: string
+  private readonly onRateLimitExceeded?: (waitSeconds: number) => void
   private readonly rateLimiter: RateLimiter
 
-  constructor(options: {apiKey: string; domain: string; onRateLimitWait?: () => void}) {
+  constructor(options: {
+    apiKey: string
+    domain: string
+    onRateLimitExceeded?: (waitSeconds: number) => void
+    onRateLimitWait?: () => void
+  }) {
     this.apiKey = options.apiKey
     this.baseUrl = `${backlogOrigin(options.domain)}/api/v2`
+    this.onRateLimitExceeded = options.onRateLimitExceeded
     this.rateLimiter = new RateLimiter(options.onRateLimitWait)
+  }
+
+  async getBinary(pathname: string, params: Record<string, string> = {}): Promise<ArrayBuffer> {
+    await this.rateLimiter.increment()
+
+    const response = await this.fetchWithRetry(this.requestUrl(pathname, params))
+    return response.arrayBuffer()
   }
 
   async getJson<T>(pathname: string, params: Record<string, string> = {}): Promise<T> {
     await this.rateLimiter.increment()
 
-    const searchParams = new URLSearchParams({apiKey: this.apiKey, ...params})
-    const url = `${this.baseUrl}${pathname}?${searchParams.toString()}`
-    const response = await this.fetchWithRetry(url)
+    const response = await this.fetchWithRetry(this.requestUrl(pathname, params))
     return (await response.json()) as T
   }
 
@@ -60,7 +85,13 @@ export class BacklogHttpClient {
       }
 
       if (attempt < MAX_RETRIES && RETRYABLE_STATUSES.has(response.status)) {
-        await sleep(RETRY_BASE_DELAY_MS * 2 ** attempt)
+        let waitMs = RETRY_BASE_DELAY_MS * 2 ** attempt
+        if (response.status === 429) {
+          waitMs = rateLimitWaitMs(response.headers.get('x-ratelimit-reset'), Date.now())
+          this.onRateLimitExceeded?.(Math.ceil(waitMs / 1000))
+        }
+
+        await sleep(waitMs)
         continue
       }
 
@@ -71,5 +102,10 @@ export class BacklogHttpClient {
 
   private maskApiKey(url: string): string {
     return url.replace(/apiKey=[^&]*/, 'apiKey=***')
+  }
+
+  private requestUrl(pathname: string, params: Record<string, string>): string {
+    const searchParams = new URLSearchParams({apiKey: this.apiKey, ...params})
+    return `${this.baseUrl}${pathname}?${searchParams.toString()}`
   }
 }

--- a/src/shared/file-name.test.ts
+++ b/src/shared/file-name.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest'
 
-import {sanitizeFileName, sanitizeWikiFileName} from './file-name.js'
+import {sanitizeAttachmentFileName, sanitizeFileName, sanitizeWikiFileName} from './file-name.js'
 
 describe('file-naming - ファイル名のサニタイズ', () => {
   describe('sanitizeFileName', () => {
@@ -45,6 +45,31 @@ describe('file-naming - ファイル名のサニタイズ', () => {
       const result = sanitizeFileName(input)
 
       expect(result).to.equal('テスト_ファイル_txt')
+    })
+  })
+
+  describe('sanitizeAttachmentFileName', () => {
+    it('拡張子のドットを保持すること', () => {
+      expect(sanitizeAttachmentFileName('image.png')).to.equal('image.png')
+    })
+
+    it('無効文字とスペースを置換しつつ拡張子を保持すること', () => {
+      expect(sanitizeAttachmentFileName('設計 資料:最終版.xlsx')).to.equal('設計_資料_最終版.xlsx')
+    })
+
+    it('200文字を超える場合は拡張子を保持したまま切り詰めること', () => {
+      const result = sanitizeAttachmentFileName(`${'a'.repeat(250)}.png`)
+
+      expect(result).to.have.length(200)
+      expect(result.endsWith('.png')).to.be.true
+    })
+
+    it('拡張子のない長い名前は単純に切り詰めること', () => {
+      expect(sanitizeAttachmentFileName('a'.repeat(250))).to.equal('a'.repeat(200))
+    })
+
+    it('拡張子自体が200文字以上の場合も200文字に収めること', () => {
+      expect(sanitizeAttachmentFileName(`a.${'b'.repeat(300)}`)).to.have.length(200)
     })
   })
 

--- a/src/shared/file-name.ts
+++ b/src/shared/file-name.ts
@@ -6,6 +6,18 @@ export function sanitizeFileName(name: string): string {
     .slice(0, 200) // 長すぎるファイル名を防ぐために200文字に制限
 }
 
+// 添付ファイル用: sanitizeFileNameと異なり、拡張子が消えないようドットを保持する
+export function sanitizeAttachmentFileName(name: string): string {
+  const sanitized = name.replaceAll(/[\\/:*?"<>|]/g, '_').replaceAll(/\s+/g, '_')
+  if (sanitized.length <= 200) return sanitized
+
+  const dotIndex = sanitized.lastIndexOf('.')
+  const extension = dotIndex > 0 ? sanitized.slice(dotIndex) : ''
+  if (extension.length === 0 || extension.length >= 200) return sanitized.slice(0, 200)
+
+  return sanitized.slice(0, 200 - extension.length) + extension
+}
+
 export function sanitizeWikiFileName(name: string): string {
   const invalidChars = ['\\', ':', '*', '?', '"', '<', '>', '|']
   let sanitizedName = name

--- a/src/shared/storage/markdown-store.ts
+++ b/src/shared/storage/markdown-store.ts
@@ -17,6 +17,19 @@ export async function writeMarkdownFile(filePath: string, content: string): Prom
   await fs.writeFile(filePath, content)
 }
 
+// 中断で壊れたファイルが完成品として残らないよう、一時ファイルに書いてからrenameする
+export async function writeBinaryFile(filePath: string, data: ArrayBuffer): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), {recursive: true})
+  const tempPath = `${filePath}.tmp`
+  await fs.writeFile(tempPath, new Uint8Array(data))
+  await fs.rename(tempPath, filePath)
+}
+
+export async function fileSize(filePath: string): Promise<null | number> {
+  const stats = await fs.stat(filePath).catch(() => null)
+  return stats?.size ?? null
+}
+
 export async function deleteFile(filePath: string): Promise<void> {
   await fs.unlink(filePath)
 }

--- a/src/shared/testing/backlog-mock-server.ts
+++ b/src/shared/testing/backlog-mock-server.ts
@@ -3,6 +3,7 @@ import {AddressInfo} from 'node:net'
 
 export interface MockResponse {
   body?: unknown
+  headers?: Record<string, string>
   status?: number
 }
 
@@ -54,8 +55,14 @@ export class BacklogMockServer {
         return
       }
 
-      const {body = {}, status = 200} = typeof responder === 'function' ? responder(url) : responder
-      res.writeHead(status, {'content-type': 'application/json'})
+      const {body = {}, headers = {}, status = 200} = typeof responder === 'function' ? responder(url) : responder
+      if (body instanceof Uint8Array) {
+        res.writeHead(status, {'content-type': 'application/octet-stream', ...headers})
+        res.end(body)
+        return
+      }
+
+      res.writeHead(status, {'content-type': 'application/json', ...headers})
       res.end(JSON.stringify(body))
     })
 


### PR DESCRIPTION
## 概要

`all` / `issue` / `update` コマンドに `-d` / `--downloadAttachments` フラグを追加し、課題の添付ファイルをローカルにダウンロードできるようにします。あわせて、本文・コメント内のインライン画像記法をローカル画像リンクに変換し、エクスポートしたMarkdownで画像がそのまま表示されるようにします。

## 変更内容

### 添付ファイルのダウンロード
- 課題一覧APIのレスポンスに含まれる `attachments` を利用（追加API呼び出しなし）。ダウンロードは `GET /issues/:key/attachments/:id` を共有RateLimiter経由で直列実行
- 保存先: デフォルトは `{年}/attachments/{課題キー}/`、`--issueKeyFolder` 時は課題フォルダ直下の `attachments/`
- ファイル名は `{添付ID}_{ファイル名}`（同名衝突の回避・DL済み判定のため。拡張子を保持する専用サニタイズを新設）
- DL済み添付はAPIの `size` との一致でスキップ（破損ファイルは自動再取得）。一時ファイル+renameのアトミック書き込み
- Markdownに `## 添付ファイル` セクションを追加（DL済みはローカル相対リンク付き、フラグ未指定時はメタデータのみ）
- 設定は `backlog-settings.json` に保存され、以降の `update` に引き継がれる
- pruneの期待パス集合に添付を追加し、`.md` 拡張子の添付が誤削除されないよう対応

### インライン画像のローカルリンク変換
- `![image][ファイル名]`（Markdown拡張）と `#image(ファイル名)`（Backlog記法）を `![ファイル名](./attachments/...)` に変換
- ファイル名照合はNFC正規化（macOSからのD&DでNFDが混入するケースに対応）。未ダウンロードの参照は原文のまま残す

### HTTPクライアントの改善（1コミット目・独立した修正）
- `getBinary()` 追加（レート制限・リトライ・apiKeyマスクを共有）
- 429受信時に `X-RateLimit-Reset` まで待機してリトライ（従来の300msバックオフは1分窓のレート制限に対して機能していなかった）し、待機秒数をログ通知

## テスト

- [x] Vitest 241件パス（本機能で+19件: DL/スキップ/失敗フォールバック/レイアウト4パターン/NFC照合/角括弧エスケープ/429待機/prune保護/設定引き継ぎ等）
- [x] 実環境（cm1.backlog.jp / PJ_CORTEX、課題53件・添付10ファイル）で検証:
  - 全添付のバイト単位のサイズ一致・形式検証（PDF/PNG/zip/HTML/md、11MB含む）
  - 日本語・スペース・丸括弧・`.md` 拡張子のファイル名
  - コメント経由で追加された添付も課題の添付一覧に含まれることを確認
  - 差分更新で「更新された課題のみ再取得・既存添付は再DLなし・新規添付のみDL」を確認
  - prune実行で `.md` 添付が削除されないことを確認
- [x] 多観点レビュー（正しさ/セキュリティ/設計整合）を2巡実施し、指摘事項（prune誤削除・非アトミック書き込み・ReDoS評価等）を反映済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)