### PR TITLE
fix: 進捗表示が前のメッセージの残骸で崩れる問題を修正

### DIFF
--- a/src/shared/console/progress.test.ts
+++ b/src/shared/console/progress.test.ts
@@ -1,0 +1,63 @@
+import process from 'node:process'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {writeProgress} from './progress.js'
+
+describe('progress - 進捗表示', () => {
+  const originalIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+  let writeSpy: ReturnType<typeof vi.spyOn>
+
+  const setIsTTY = (value: boolean | undefined): void => {
+    Object.defineProperty(process.stdout, 'isTTY', {configurable: true, value})
+  }
+
+  beforeEach(() => {
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    writeSpy.mockRestore()
+    if (originalIsTTY) {
+      Object.defineProperty(process.stdout, 'isTTY', originalIsTTY)
+    }
+  })
+
+  describe('writeProgress', () => {
+    it('TTYの場合、行頭復帰と行末消去シーケンス付きでメッセージを書き込むこと', () => {
+      setIsTTY(true)
+
+      writeProgress('課題を取得中... (1/10件)')
+
+      expect(writeSpy).toHaveBeenCalledOnce()
+      expect(writeSpy).toHaveBeenCalledWith('\r\u001B[K課題を取得中... (1/10件)')
+    })
+
+    it('TTYの場合、短いメッセージへの切り替えでも消去シーケンスが先頭に付くこと', () => {
+      setIsTTY(true)
+
+      writeProgress('ドキュメント「とても長い名前のドキュメント」を処理中...')
+      writeProgress('短い名前')
+
+      expect(writeSpy).toHaveBeenNthCalledWith(2, '\r\u001B[K短い名前')
+    })
+
+    it('非TTYの場合、改行付きでメッセージを書き込むこと', () => {
+      setIsTTY(false)
+
+      writeProgress('Wikiを保存中... (5/20件)')
+
+      expect(writeSpy).toHaveBeenCalledOnce()
+      expect(writeSpy).toHaveBeenCalledWith('Wikiを保存中... (5/20件)\n')
+    })
+
+    it('非TTYの場合、行頭復帰や消去シーケンスを含まないこと', () => {
+      setIsTTY(false)
+
+      writeProgress('進捗メッセージ')
+
+      const written = writeSpy.mock.calls[0][0] as string
+      expect(written).not.to.include('\r')
+      expect(written).not.to.include('\u001B[K')
+    })
+  })
+})

--- a/src/shared/console/progress.ts
+++ b/src/shared/console/progress.ts
@@ -1,5 +1,11 @@
 import process from 'node:process'
 
 export function writeProgress(message: string): void {
-  process.stdout.write(`\r${message}`)
+  if (process.stdout.isTTY) {
+    // ESC[K でカーソル位置から行末まで消去し、前の長いメッセージの残骸を防ぐ
+    process.stdout.write(`\r\u001B[K${message}`)
+  } else {
+    // 非TTY（CIログ・パイプ）では \r が効かず1行に連結されるため改行して出力する
+    process.stdout.write(`${message}\n`)
+  }
 }


### PR DESCRIPTION
## 概要

`writeProgress` が `\r`（行頭復帰）だけで進捗表示を上書きしていたため、直前のメッセージより表示幅が短いメッセージを書くと、前のメッセージの残骸が行末に残って表示が崩れていました。特にドキュメント名を含む `ドキュメント「${node.name}」を処理中...`（`export-documents.ts`）のように長さがバラバラなメッセージで顕著でした。

## Before

```
ドキュメント「xxx」を処理中... ....処理中... 理中......構造（xxx）」へ」を処理中...
```

## After

- **TTY時**: `\r` + ANSI消去シーケンス `ESC[K`（カーソル位置から行末まで消去）を付けて書き込むことで、短いメッセージへの切り替えでも残骸が残らない
- **非TTY時（CIログ・パイプ）**: `\r` は意味を持たず1行に連結されてログが読めなくなるため、メッセージ + 改行 `\n` を出力する

## テスト

`src/shared/console/progress.test.ts` を新規追加し、`process.stdout.write` をspyでモックして以下を検証:

- TTY時に `\r` + `ESC[K` プレフィックス付きで書き込むこと
- TTY時に短いメッセージへ切り替えても消去シーケンスが付くこと
- 非TTY時に改行付きで書き込むこと（`\r` / `ESC[K` を含まないこと）

- `npm run lint`: passed
- `npm test`: 245 passed (26 files)
- `npm run test:e2e`: 15 passed (4 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)