### PR TITLE
feat: Wiki・ドキュメントの添付ファイルダウンロードに対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,14 +169,19 @@ $ backlog-exporter issue --domain example.backlog.jp --projectIdOrKey PROJECT_KE
 
 ## 添付ファイルのダウンロード
 
-`--downloadAttachments`（短縮形: `-d`）フラグを指定すると、課題の添付ファイルもダウンロードされます（`all` / `issue` / `update` コマンドで使用可能）。
+`--downloadAttachments`（短縮形: `-d`）フラグを指定すると、課題・Wiki・ドキュメントの添付ファイルもダウンロードされます（`all` / `issue` / `wiki` / `document` / `update` コマンドで使用可能）。
 
-- 保存先はデフォルトでは `{年}/attachments/{課題キー}/`、`--issueKeyFolder` 指定時は課題フォルダ直下の `attachments/` です
+- 保存先:
+  - 課題: デフォルトは `{年}/attachments/{課題キー}/`、`--issueKeyFolder` 指定時は課題フォルダ直下の `attachments/`
+  - Wiki: Markdownと同じディレクトリの `attachments/{Wiki名}/`（階層Wikiは末尾のページ名）
+  - ドキュメント: Markdownと同じディレクトリの `attachments/{ドキュメント名}/`
 - ファイル名は同名の衝突を避けるため `{添付ID}_{ファイル名}` になります
 - Markdown の `## 添付ファイル` セクションにローカルファイルへの相対リンクが記載されます（フラグ未指定時はファイル名とサイズのみ記載）
-- 本文・コメント内の添付画像のインライン記法（`![image][ファイル名]` / `#image(ファイル名)`）は、ダウンロード済みファイルへの画像リンクに変換され、Markdownビューアでそのまま表示できます
+- 課題の本文・コメント内の添付画像のインライン記法（`![image][ファイル名]` / `#image(ファイル名)`）は、ダウンロード済みファイルへの画像リンクに変換され、Markdownビューアでそのまま表示できます
+- Wiki・ドキュメントの本文はBacklogの原文のまま維持されます（添付参照記法の書き換えは行いません）。添付ファイルへは `## 添付ファイル` セクションのリンクからアクセスできます
 - ダウンロード済みのファイルは再ダウンロードされないため、`update` コマンドでの差分更新でも効率的に動作します
-- 設定は `backlog-settings.json` に保存され、以降の `update` コマンドで自動的に引き継がれます
+- 設定は `backlog-settings.json` に保存され、以降の `update` コマンドで自動的に引き継がれます（`update` コマンド自体でフラグを指定した場合はその実行のみ有効です）
+- Backlog側で削除された添付ファイルは、誤削除防止のため `prune` コマンドでも削除されず残ります
 
 ## カスタム属性の対応
 

--- a/src/commands/document/base.test.ts
+++ b/src/commands/document/base.test.ts
@@ -80,3 +80,14 @@ describe('Documentコマンド - 基本機能', () => {
     })
   })
 })
+
+describe('Documentコマンド - 添付ファイルダウンロードフラグ', () => {
+  it('downloadAttachmentsフラグが正しく設定されていること', () => {
+    const {flags} = Document
+
+    expect(flags.downloadAttachments).to.exist
+    expect(flags.downloadAttachments.required).to.be.false
+    expect(flags.downloadAttachments.char).to.equal('d')
+    expect(flags.downloadAttachments.description).to.include('添付ファイル')
+  })
+})

--- a/src/commands/document/index.ts
+++ b/src/commands/document/index.ts
@@ -32,6 +32,11 @@ export default class Document extends Command {
       description: 'Backlog domain (e.g. example.backlog.jp)',
       required: true,
     }),
+    downloadAttachments: Flags.boolean({
+      char: 'd',
+      description: '添付ファイルもダウンロードする',
+      required: false,
+    }),
     keyword: Flags.string({
       description: '検索キーワード',
       required: false,
@@ -51,7 +56,7 @@ export default class Document extends Command {
     const {flags} = await this.parse(Document)
 
     try {
-      const {domain, keyword, projectIdOrKey} = flags
+      const {domain, downloadAttachments, keyword, projectIdOrKey} = flags
       const apiKey =
         resolveApiKey(flags.apiKey, () => this.log('環境変数 BACKLOG_API_KEY からAPIキーを使用します')) ??
         this.error(API_KEY_NOT_FOUND_MESSAGE)
@@ -76,6 +81,7 @@ export default class Document extends Command {
       await updateSettings(outputDir, {
         apiKey,
         domain,
+        downloadAttachments,
         folderType: FolderType.DOCUMENT,
         outputDir,
         projectIdOrKey,
@@ -86,6 +92,7 @@ export default class Document extends Command {
         {documentRepository, logger},
         {
           domain,
+          downloadAttachments,
           keyword,
           outputDir,
           projectId,

--- a/src/commands/wiki/base.test.ts
+++ b/src/commands/wiki/base.test.ts
@@ -83,3 +83,14 @@ describe('Wikiコマンド - 基本機能', () => {
     })
   })
 })
+
+describe('Wikiコマンド - 添付ファイルダウンロードフラグ', () => {
+  it('downloadAttachmentsフラグが正しく設定されていること', () => {
+    const {flags} = Wiki
+
+    expect(flags.downloadAttachments).to.exist
+    expect(flags.downloadAttachments.required).to.be.false
+    expect(flags.downloadAttachments.char).to.equal('d')
+    expect(flags.downloadAttachments.description).to.include('添付ファイル')
+  })
+})

--- a/src/commands/wiki/index.ts
+++ b/src/commands/wiki/index.ts
@@ -29,6 +29,11 @@ Wikiをダウンロードする
       description: 'Backlog domain (e.g. example.backlog.jp)',
       required: true,
     }),
+    downloadAttachments: Flags.boolean({
+      char: 'd',
+      description: '添付ファイルもダウンロードする',
+      required: false,
+    }),
     output: Flags.string({
       char: 'o',
       description: '出力ディレクトリパス',
@@ -44,7 +49,7 @@ Wikiをダウンロードする
     const {flags} = await this.parse(Wiki)
 
     try {
-      const {domain, projectIdOrKey} = flags
+      const {domain, downloadAttachments, projectIdOrKey} = flags
       const apiKey =
         resolveApiKey(flags.apiKey, () => this.log('環境変数 BACKLOG_API_KEY からAPIキーを使用します')) ??
         this.error(API_KEY_NOT_FOUND_MESSAGE)
@@ -65,6 +70,7 @@ Wikiをダウンロードする
       await updateSettings(outputDir, {
         apiKey,
         domain,
+        downloadAttachments,
         folderType: FolderType.WIKI,
         outputDir,
         projectIdOrKey,
@@ -75,6 +81,7 @@ Wikiをダウンロードする
         {logger, wikiRepository},
         {
           domain,
+          downloadAttachments,
           outputDir,
           projectIdOrKey,
         },

--- a/src/modules/all/use-case/export-all.ts
+++ b/src/modules/all/use-case/export-all.ts
@@ -84,6 +84,7 @@ export async function exportAll(deps: ExportAllDeps, options: ExportAllOptions):
     await updateSettings(wikiOutput, {
       apiKey,
       domain,
+      downloadAttachments,
       folderType: FolderType.WIKI,
       outputDir: wikiOutput,
       projectIdOrKey,
@@ -94,6 +95,7 @@ export async function exportAll(deps: ExportAllDeps, options: ExportAllOptions):
       {logger, wikiRepository},
       {
         domain,
+        downloadAttachments,
         outputDir: wikiOutput,
         projectIdOrKey,
       },
@@ -110,6 +112,7 @@ export async function exportAll(deps: ExportAllDeps, options: ExportAllOptions):
     await updateSettings(documentOutput, {
       apiKey,
       domain,
+      downloadAttachments,
       folderType: FolderType.DOCUMENT,
       outputDir: documentOutput,
       projectIdOrKey,
@@ -120,6 +123,7 @@ export async function exportAll(deps: ExportAllDeps, options: ExportAllOptions):
       {documentRepository, logger},
       {
         domain,
+        downloadAttachments,
         outputDir: documentOutput,
         projectId,
         projectIdOrKey,

--- a/src/modules/document/domain/document-markdown.ts
+++ b/src/modules/document/domain/document-markdown.ts
@@ -1,15 +1,23 @@
+import {escapeLinkText} from '../../../shared/attachment.js'
 import {wrapBody} from '../../../shared/markdown/body-marker.js'
 import {DocumentDetail} from './document.js'
 
-export function buildDocumentMarkdown(documentDetail: DocumentDetail, backlogDocumentUrl: string): string {
-  // 添付ファイルリストの作成
+
+export function buildDocumentMarkdown(
+  documentDetail: DocumentDetail,
+  backlogDocumentUrl: string,
+  attachmentLinks?: Map<number, string>,
+): string {
+  // 添付ファイルリストの作成（ダウンロード済みはローカルへの相対リンク付き）
   let attachmentsSection = ''
   if (documentDetail.attachments && documentDetail.attachments.length > 0) {
     attachmentsSection = '\n\n## 添付ファイル\n'
     for (const attachment of documentDetail.attachments) {
       const attachmentDate = new Date(attachment.created).toLocaleString('ja-JP')
       const fileSize = (attachment.size / 1024).toFixed(1)
-      attachmentsSection += `- **${attachment.name}** (${fileSize} KB) - 作成者: ${attachment.createdUser.name}, 作成日時: ${attachmentDate}\n`
+      const link = attachmentLinks?.get(attachment.id)
+      const label = link ? `[${escapeLinkText(attachment.name)}](${link})` : `**${attachment.name}**`
+      attachmentsSection += `- ${label} (${fileSize} KB) - 作成者: ${attachment.createdUser.name}, 作成日時: ${attachmentDate}\n`
     }
   }
 

--- a/src/modules/document/domain/document-path.ts
+++ b/src/modules/document/domain/document-path.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 
+import {attachmentFileName, encodeLinkDestination} from '../../../shared/attachment.js'
 import {backlogOrigin} from '../../../shared/backlog-url.js'
 import {sanitizeFileName} from '../../../shared/file-name.js'
 import {ExpectedPaths} from '../../prune/domain/expected-paths.js'
@@ -18,6 +19,22 @@ export function documentFileName(title: string, asParentIndex: boolean): string 
 
 export function documentUrl(domain: string, projectIdOrKey: string, documentId: string): string {
   return `${backlogOrigin(domain)}/document/${projectIdOrKey}/${documentId}`
+}
+
+// 添付の保存先はMarkdownと同じディレクトリの attachments/{ドキュメント名}/ 配下。
+// タイトル改名時は再ダウンロードになるが、Markdown本体（{タイトル}.md）と同じ挙動で閲覧性を優先する
+export function documentAttachmentRelativePath(
+  currentPath: string,
+  documentTitle: string,
+  attachment: {id: number; name: string},
+): string {
+  return path.join(currentPath, 'attachments', sanitizeFileName(documentTitle), attachmentFileName(attachment))
+}
+
+export function documentAttachmentMarkdownLink(documentTitle: string, attachment: {id: number; name: string}): string {
+  return encodeLinkDestination(
+    ['.', 'attachments', sanitizeFileName(documentTitle), attachmentFileName(attachment)].join('/'),
+  )
 }
 
 export interface DocumentTreePaths extends ExpectedPaths {

--- a/src/modules/document/domain/document-repository.ts
+++ b/src/modules/document/domain/document-repository.ts
@@ -1,6 +1,7 @@
 import {DocumentDetail, DocumentTree} from './document.js'
 
 export interface DocumentRepository {
+  downloadAttachment(documentId: string, attachmentId: number): Promise<ArrayBuffer>
   fetchAllTitles(projectId: number): Promise<Map<string, string>>
   fetchDetail(documentId: string): Promise<DocumentDetail>
   fetchTree(projectId: number): Promise<DocumentTree>

--- a/src/modules/document/repository/backlog-document-repository.ts
+++ b/src/modules/document/repository/backlog-document-repository.ts
@@ -4,6 +4,11 @@ import {DocumentDetail, DocumentTree} from '../domain/document.js'
 
 export function newBacklogDocumentRepository(client: BacklogHttpClient): DocumentRepository {
   return {
+    // 公式ドキュメント未記載だが公式SDK(nulab/backlog-js)に存在するエンドポイント
+    async downloadAttachment(documentId, attachmentId) {
+      return client.getBinary(`/documents/${documentId}/attachments/${attachmentId}`)
+    },
+
     async fetchAllTitles(projectId) {
       const titlesById = new Map<string, string>()
       const pageSize = 100

--- a/src/modules/document/use-case/export-documents.test.ts
+++ b/src/modules/document/use-case/export-documents.test.ts
@@ -220,4 +220,113 @@ describe('exportDocuments', () => {
       expect(existsSync(join(outputDir, '親フォルダ', '子A.md')), '子は保存されること').to.be.true
     })
   })
+
+  describe('添付ファイルのダウンロード', () => {
+    it('downloadAttachments指定時に添付を保存し、Markdownにローカルリンクを記載すること', async () => {
+      const binary = new Uint8Array([1, 2, 3, 4])
+      respondTree([{children: [], id: 'docA', name: 'ドキュメントA'}])
+      server.respond('/api/v2/documents/docA', {
+        body: {
+          ...documentDetail('docA', 'ドキュメントA', '本文'),
+          attachments: [
+            {created: '2026-01-01T00:00:00Z', createdUser: {id: 1, name: '作成者'}, id: 77, name: 'design.png', size: 4},
+          ],
+        },
+      })
+      server.respond('/api/v2/documents/docA/attachments/77', {body: binary})
+
+      await exportDocuments(
+        {documentRepository: newBacklogDocumentRepository(client()), logger: stubLogger},
+        exportOptions({downloadAttachments: true}),
+      )
+
+      const saved = await fs.readFile(join(outputDir, 'attachments', 'ドキュメントA', '77_design.png'))
+      expect(new Uint8Array(saved)).to.deep.equal(binary)
+
+      const content = await fs.readFile(join(outputDir, 'ドキュメントA.md'), 'utf8')
+      expect(content).to.include('- [design.png](./attachments/ドキュメントA/77_design.png) (0.0 KB) - 作成者: 作成者')
+    })
+
+    it('フォルダ配下のドキュメントの添付はフォルダ内のattachmentsに保存されること', async () => {
+      respondTree([{children: [{children: [], id: 'childA', name: '子A'}], id: 'parent1', name: '親フォルダ'}])
+      server.respond('/api/v2/documents/parent1', {body: documentDetail('parent1', '親フォルダ', '')})
+      server.respond('/api/v2/documents/childA', {
+        body: {
+          ...documentDetail('childA', '子A', 'A本文'),
+          attachments: [
+            {created: '2026-01-01T00:00:00Z', createdUser: {id: 1, name: '作成者'}, id: 78, name: 'log.txt', size: 2},
+          ],
+        },
+      })
+      server.respond('/api/v2/documents/childA/attachments/78', {body: new Uint8Array([5, 6])})
+
+      await exportDocuments(
+        {documentRepository: newBacklogDocumentRepository(client()), logger: stubLogger},
+        exportOptions({downloadAttachments: true}),
+      )
+
+      expect(existsSync(join(outputDir, '親フォルダ', 'attachments', '子A', '78_log.txt'))).to.be.true
+      const content = await fs.readFile(join(outputDir, '親フォルダ', '子A.md'), 'utf8')
+      expect(content).to.include('- [log.txt](./attachments/子A/78_log.txt)')
+    })
+
+    it('downloadAttachments指定時も本文中の参照はBacklogの原文のまま維持すること', async () => {
+      const plain = [
+        '説明',
+        '![](/document/backend/TEST/docA/file/77){width="415" height="233" uuid="x" textAlign="center"}',
+        '[attachmentBadge id="78" projectKey="TEST" documentId="docA" uuid="y" attachmentUrl="/document/backend/TEST/docA/file/78" filename="資料.pdf" size="2" created="2026-01-01T00:00:00Z"]',
+      ].join('\n')
+      respondTree([{children: [], id: 'docA', name: 'ドキュメントA'}])
+      server.respond('/api/v2/documents/docA', {
+        body: {
+          ...documentDetail('docA', 'ドキュメントA', plain),
+          attachments: [
+            {created: '2026-01-01T00:00:00Z', createdUser: {id: 1, name: '作成者'}, id: 77, name: '図.png', size: 4},
+            {created: '2026-01-01T00:00:00Z', createdUser: {id: 1, name: '作成者'}, id: 78, name: '資料.pdf', size: 2},
+          ],
+        },
+      })
+      server.respond('/api/v2/documents/docA/attachments/77', {body: new Uint8Array([1, 2, 3, 4])})
+      server.respond('/api/v2/documents/docA/attachments/78', {body: new Uint8Array([5, 6])})
+
+      await exportDocuments(
+        {documentRepository: newBacklogDocumentRepository(client()), logger: stubLogger},
+        exportOptions({downloadAttachments: true}),
+      )
+
+      const content = await fs.readFile(join(outputDir, 'ドキュメントA.md'), 'utf8')
+      expect(content, '本文は原文のまま').to.include(plain)
+      expect(content, '添付セクションにはローカルリンクが付くこと').to.include(
+        '- [図.png](./attachments/ドキュメントA/77_図.png)',
+      )
+    })
+
+    it('downloadAttachments未指定時はダウンロードせず、メタデータのみ記載すること', async () => {
+      respondTree([{children: [], id: 'docA', name: 'ドキュメントA'}])
+      server.respond('/api/v2/documents/docA', {
+        body: {
+          ...documentDetail('docA', 'ドキュメントA', '本文'),
+          attachments: [
+            {
+              created: '2026-01-01T00:00:00Z',
+              createdUser: {id: 1, name: '作成者'},
+              id: 77,
+              name: 'design.png',
+              size: 2048,
+            },
+          ],
+        },
+      })
+
+      await exportDocuments(
+        {documentRepository: newBacklogDocumentRepository(client()), logger: stubLogger},
+        exportOptions(),
+      )
+
+      expect(server.requestedPaths()).to.not.include('/api/v2/documents/docA/attachments/77')
+      const content = await fs.readFile(join(outputDir, 'ドキュメントA.md'), 'utf8')
+      expect(content).to.include('- **design.png** (2.0 KB)')
+      expect(content).to.not.include('](./attachments')
+    })
+  })
 })

--- a/src/modules/document/use-case/export-documents.ts
+++ b/src/modules/document/use-case/export-documents.ts
@@ -2,10 +2,19 @@ import path from 'node:path'
 
 import {writeProgress} from '../../../shared/console/progress.js'
 import {Logger} from '../../../shared/ports.js'
-import {deleteFile, ensureDirectory, fileExists, writeMarkdownFile} from '../../../shared/storage/markdown-store.js'
+import {
+  deleteFile,
+  ensureDirectory,
+  fileExists,
+  fileSize,
+  writeBinaryFile,
+  writeMarkdownFile,
+} from '../../../shared/storage/markdown-store.js'
 import {appendLog} from '../../../shared/storage/update-log.js'
 import {buildDocumentMarkdown} from '../domain/document-markdown.js'
 import {
+  documentAttachmentMarkdownLink,
+  documentAttachmentRelativePath,
   documentFileName,
   documentFolderPath,
   documentUrl,
@@ -13,7 +22,7 @@ import {
 } from '../domain/document-path.js'
 import {DocumentRepository} from '../domain/document-repository.js'
 import {planDocumentSave} from '../domain/document-save-plan.js'
-import {DocumentNode} from '../domain/document.js'
+import {DocumentDetail, DocumentNode} from '../domain/document.js'
 
 export interface ExportDocumentsDeps {
   documentRepository: DocumentRepository
@@ -23,6 +32,7 @@ export interface ExportDocumentsDeps {
 export interface ExportDocumentsOptions {
   documentIds?: string[]
   domain: string
+  downloadAttachments?: boolean
   keyword?: string
   lastUpdated?: string
   outputDir: string
@@ -87,7 +97,10 @@ export async function exportDocuments(deps: ExportDocumentsDeps, options: Export
 
         case 'save': {
           const backlogDocumentUrl = documentUrl(options.domain, options.projectIdOrKey, node.id)
-          await writeMarkdownFile(filePath, buildDocumentMarkdown(documentDetail, backlogDocumentUrl))
+          const attachmentLinks = options.downloadAttachments
+            ? await downloadDocumentAttachments(deps, documentDetail, currentPath, options.outputDir)
+            : undefined
+          await writeMarkdownFile(filePath, buildDocumentMarkdown(documentDetail, backlogDocumentUrl, attachmentLinks))
           writtenFiles.add(filePath)
           await appendLog(
             options.outputDir,
@@ -137,4 +150,41 @@ export async function exportDocuments(deps: ExportDocumentsDeps, options: Export
 
   logger.log(`\n合計 ${processedDocuments.length}件のドキュメントが処理されました。`)
   logger.log('ドキュメントのダウンロードが完了しました！')
+}
+
+// 保存できた添付のみリンク化する。個々の失敗は警告に留め、ドキュメント本体の保存は続行する
+async function downloadDocumentAttachments(
+  deps: ExportDocumentsDeps,
+  documentDetail: DocumentDetail,
+  currentPath: string,
+  outputDir: string,
+): Promise<Map<number, string>> {
+  const links = new Map<number, string>()
+
+  for (const attachment of documentDetail.attachments ?? []) {
+    const absolutePath = path.join(
+      outputDir,
+      documentAttachmentRelativePath(currentPath, documentDetail.title, attachment),
+    )
+    try {
+      // 添付IDは不変のため、サイズの一致するファイルが既にあれば再ダウンロードしない
+      // eslint-disable-next-line no-await-in-loop
+      if ((await fileSize(absolutePath)) !== attachment.size) {
+        // eslint-disable-next-line no-await-in-loop
+        const data = await deps.documentRepository.downloadAttachment(documentDetail.id, attachment.id)
+        // eslint-disable-next-line no-await-in-loop
+        await writeBinaryFile(absolutePath, data)
+      }
+
+      links.set(attachment.id, documentAttachmentMarkdownLink(documentDetail.title, attachment))
+    } catch (error) {
+      deps.logger.warn(
+        `ドキュメント「${documentDetail.title}」の添付ファイル「${attachment.name}」の取得に失敗しました: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      )
+    }
+  }
+
+  return links
 }

--- a/src/modules/issue/domain/issue-markdown.test.ts
+++ b/src/modules/issue/domain/issue-markdown.test.ts
@@ -1,71 +1,8 @@
 import {describe, expect, it} from 'vitest'
 
-import {buildCommentsSection, createCustomFieldsSection, rewriteInlineImages} from './issue-markdown.js'
+import {buildCommentsSection, createCustomFieldsSection} from './issue-markdown.js'
 
 describe('issue-markdown', () => {
-  describe('rewriteInlineImages', () => {
-    const attachments = [
-      {id: 10, name: 'design.png', size: 100},
-      {id: 11, name: 'スクリーンショット 2026-06-18 12.37.25.png', size: 200},
-    ]
-    const links = new Map([
-      [10, './attachments/TEST-1/10_design.png'],
-      [11, './attachments/TEST-1/11_スクリーンショット_2026-06-18_12.37.25.png'],
-    ])
-
-    it('Markdown拡張記法 ![image][ファイル名] をローカルリンクに変換すること', () => {
-      const result = rewriteInlineImages('前文\n![image][design.png]\n後文', attachments, links)
-      expect(result).to.equal('前文\n![design.png](./attachments/TEST-1/10_design.png)\n後文')
-    })
-
-    it('スペース入り日本語ファイル名も変換すること', () => {
-      const result = rewriteInlineImages('![image][スクリーンショット 2026-06-18 12.37.25.png]', attachments, links)
-      expect(result).to.equal(
-        '![スクリーンショット 2026-06-18 12.37.25.png](./attachments/TEST-1/11_スクリーンショット_2026-06-18_12.37.25.png)',
-      )
-    })
-
-    it('Backlog記法 #image(ファイル名) をローカルリンクに変換すること', () => {
-      const result = rewriteInlineImages('#image(design.png)', attachments, links)
-      expect(result).to.equal('![design.png](./attachments/TEST-1/10_design.png)')
-    })
-
-    it('添付一覧にないファイル名の参照はそのまま残すこと', () => {
-      const text = '![image][unknown.png] と #image(other.png)'
-      expect(rewriteInlineImages(text, attachments, links)).to.equal(text)
-    })
-
-    it('ダウンロードされていない添付への参照はそのまま残すこと', () => {
-      const text = '![image][design.png]'
-      expect(rewriteInlineImages(text, attachments, new Map())).to.equal(text)
-      expect(rewriteInlineImages(text, attachments)).to.equal(text)
-    })
-
-    it('NFD（結合濁点）の参照名をNFCの添付名と照合できること', () => {
-      const nfdName = 'ドリンク.png'.normalize('NFD')
-      const result = rewriteInlineImages(
-        `![image][${nfdName}]`,
-        [{id: 20, name: 'ドリンク.png'.normalize('NFC'), size: 10}],
-        new Map([[20, './attachments/TEST-1/20_ドリンク.png']]),
-      )
-      expect(result).to.equal(`![${nfdName}](./attachments/TEST-1/20_ドリンク.png)`)
-    })
-
-    it('ファイル名中の角括弧をエスケープすること', () => {
-      const result = rewriteInlineImages(
-        '#image(x]y.png)',
-        [{id: 30, name: 'x]y.png', size: 10}],
-        new Map([[30, './attachments/TEST-1/30_x_y.png']]),
-      )
-      expect(result).to.equal(String.raw`![x\]y.png](./attachments/TEST-1/30_x_y.png)`)
-    })
-
-    it('通常の参照リンク（添付名と一致しないラベル）を壊さないこと', () => {
-      const text = '![alt text][ref1]\n\n[ref1]: https://example.com/a.png'
-      expect(rewriteInlineImages(text, attachments, links)).to.equal(text)
-    })
-  })
-
   describe('createCustomFieldsSection', () => {
     it('空の配列の場合は空文字列を返すこと', () => {
       const result = createCustomFieldsSection([])

--- a/src/modules/issue/domain/issue-markdown.ts
+++ b/src/modules/issue/domain/issue-markdown.ts
@@ -1,3 +1,4 @@
+import {escapeLinkText, rewriteInlineImages} from '../../../shared/attachment.js'
 import {wrapBody} from '../../../shared/markdown/body-marker.js'
 import {CustomField, Issue, IssueAttachment, IssueComment, IssueCommentChange} from './issue.js'
 
@@ -33,38 +34,6 @@ function formatChangeValue(value: null | string): string {
 function formatChange(change: IssueCommentChange): string {
   const label = CHANGE_FIELD_LABELS[change.field] ?? change.field
   return `- ${label}: ${formatChangeValue(change.originalValue)} → ${formatChangeValue(change.newValue)}`
-}
-
-// Backlogの添付画像インライン記法（Markdown拡張の ![alt][ファイル名] とBacklog記法の #image(ファイル名)）を
-// ダウンロード済みファイルへのローカルリンクに変換する。未ダウンロードの参照は壊さずそのまま残す
-export function rewriteInlineImages(
-  text: string,
-  attachments: IssueAttachment[] | undefined,
-  localLinks?: Map<number, string>,
-): string {
-  if (!text || !attachments || attachments.length === 0 || !localLinks || localLinks.size === 0) {
-    return text
-  }
-
-  // 同名添付が複数ある場合は記法から特定できないため先勝ちで解決する。
-  // 記法内のファイル名はNFD（macOSからのD&D等）で入ることがあるため、照合はNFC正規化で行う
-  const linkByName = new Map<string, string>()
-  for (const attachment of attachments) {
-    const link = localLinks.get(attachment.id)
-    const name = attachment.name.normalize('NFC')
-    if (link && !linkByName.has(name)) {
-      linkByName.set(name, link)
-    }
-  }
-
-  const toLocalImage = (match: string, name: string) => {
-    const link = linkByName.get(name.normalize('NFC'))
-    return link ? `![${escapeLinkText(name)}](${link})` : match
-  }
-
-  return text
-    .replaceAll(/!\[[^\]]*\]\[([^\]]+)\]/g, toLocalImage)
-    .replaceAll(/#image\(([^)]+)\)/g, toLocalImage)
 }
 
 function buildCommentBody(comment: IssueComment, rewriteBody: (text: string) => string): string {
@@ -113,11 +82,6 @@ export function createCustomFieldsSection(customFields?: CustomField[]): string 
   }
 
   return customFieldsSection
-}
-
-// ファイル名中の角括弧はリンク構文を壊すためエスケープする
-function escapeLinkText(name: string): string {
-  return name.replaceAll('[', String.raw`\[`).replaceAll(']', String.raw`\]`)
 }
 
 // ダウンロード済みの添付はローカルへの相対リンク付き、未ダウンロードはメタデータのみを出力する

--- a/src/modules/issue/domain/issue-path.ts
+++ b/src/modules/issue/domain/issue-path.ts
@@ -1,7 +1,8 @@
 import path from 'node:path'
 
+import {attachmentFileName, encodeLinkDestination} from '../../../shared/attachment.js'
 import {backlogOrigin} from '../../../shared/backlog-url.js'
-import {sanitizeAttachmentFileName, sanitizeFileName} from '../../../shared/file-name.js'
+import {sanitizeFileName} from '../../../shared/file-name.js'
 import {ExpectedPaths} from '../../prune/domain/expected-paths.js'
 import {Issue, IssueAttachment} from './issue.js'
 
@@ -24,11 +25,6 @@ export function issueRelativePath(
   )
 }
 
-// 添付IDを前置して同一課題内の同名添付の衝突を防ぎ、存在チェックだけでDL済み判定できるようにする
-export function attachmentFileName(attachment: Pick<IssueAttachment, 'id' | 'name'>): string {
-  return `${attachment.id}_${sanitizeAttachmentFileName(attachment.name)}`
-}
-
 // issueKeyFolderありなら課題フォルダ直下のattachments/、なしなら年フォルダのattachments/{課題キー}/
 function attachmentDirSegments(issueKey: string, useIssueKeyFolder: boolean): string[] {
   return useIssueKeyFolder ? ['attachments'] : ['attachments', issueKey]
@@ -46,14 +42,13 @@ export function attachmentRelativePath(
   )
 }
 
-// Markdownファイルから添付への相対リンク。丸括弧はインラインリンクを壊すためエンコードする
 export function attachmentMarkdownLink(
   issue: {issueKey: string},
   attachment: Pick<IssueAttachment, 'id' | 'name'>,
   options: {issueKeyFolder?: boolean},
 ): string {
   const segments = attachmentDirSegments(issue.issueKey, options.issueKeyFolder ?? false)
-  return ['.', ...segments, attachmentFileName(attachment)].join('/').replaceAll('(', '%28').replaceAll(')', '%29')
+  return encodeLinkDestination(['.', ...segments, attachmentFileName(attachment)].join('/'))
 }
 
 export function issueUrl(domain: string, issueKey: string): string {
@@ -68,23 +63,13 @@ export function buildIssueExpectedPaths(
   const expectedFiles = new Set<string>()
   const expectedDirs = new Set<string>()
 
-  const addDirs = (dir: string) => {
-    let current = dir
-    while (current && current !== '.') {
-      expectedDirs.add(current.normalize('NFC'))
-      current = path.dirname(current)
-    }
-  }
-
   for (const issue of issues) {
     expectedFiles.add(issueRelativePath(issue, options).normalize('NFC'))
-    addDirs(issueRelativeDir(issue, options.issueKeyFolder ?? false))
 
-    // .md拡張子の添付ファイルがpruneで誤削除されないよう、添付パスも期待集合に含める
-    for (const attachment of issue.attachments ?? []) {
-      const attachmentPath = attachmentRelativePath(issue, attachment, options)
-      expectedFiles.add(attachmentPath.normalize('NFC'))
-      addDirs(path.dirname(attachmentPath))
+    let dir = issueRelativeDir(issue, options.issueKeyFolder ?? false)
+    while (dir && dir !== '.') {
+      expectedDirs.add(dir.normalize('NFC'))
+      dir = path.dirname(dir)
     }
   }
 

--- a/src/modules/prune/repository/prune-walker.ts
+++ b/src/modules/prune/repository/prune-walker.ts
@@ -26,6 +26,12 @@ export async function pruneLocalMarkdownFiles(options: {
       const fullPath = path.join(dir, entry.name)
       const relativePath = path.relative(options.outputDir, fullPath).normalize('NFC')
       if (entry.isDirectory()) {
+        // 添付ファイルの保存先。Wiki・ドキュメントのpruneは一覧APIしか呼ばず添付の期待パスを持てないため、
+        // attachments/ 配下は走査せず丸ごと保護する（.md形式の添付の誤削除防止）
+        if (entry.name === 'attachments') {
+          continue
+        }
+
         await pruneDirectory(fullPath)
 
         const remaining = await fs.readdir(fullPath)

--- a/src/modules/prune/use-case/prune-exports.test.ts
+++ b/src/modules/prune/use-case/prune-exports.test.ts
@@ -240,6 +240,22 @@ describe('pruneWikis（不要なローカルWikiの削除）', () => {
     expect(existsSync(join(outputDir, 'WikiB.md')), 'WikiB.md は削除されること').to.be.false
   })
 
+  it('attachmentsディレクトリ配下は.md形式の添付があっても削除しないこと', async () => {
+    server.respond('/api/v2/wikis', {body: [{id: '1', name: 'WikiA', updated: '2026-01-01T00:00:00Z'}]})
+
+    await fs.writeFile(join(outputDir, 'WikiA.md'), '# WikiA')
+    await fs.mkdir(join(outputDir, 'attachments', '1'), {recursive: true})
+    await fs.writeFile(join(outputDir, 'attachments', '1', '9_notes.md'), '# 添付本体')
+
+    const pruned = await pruneWikis(
+      {logger: stubLogger, wikiRepository: newBacklogWikiRepository(client())},
+      {outputDir, projectIdOrKey: PROJECT_KEY},
+    )
+
+    expect(pruned).to.equal(0)
+    expect(existsSync(join(outputDir, 'attachments', '1', '9_notes.md'))).to.be.true
+  })
+
   it('スラッシュを含むWiki名（階層）のファイルを正しく扱い、空ディレクトリを削除すること', async () => {
     server.respond('/api/v2/wikis', {body: [{id: '1', name: '親/子A', updated: '2026-01-01T00:00:00Z'}]})
 

--- a/src/modules/update/use-case/update-exports.test.ts
+++ b/src/modules/update/use-case/update-exports.test.ts
@@ -1,0 +1,108 @@
+import {existsSync} from 'node:fs'
+import * as fs from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it} from 'vitest'
+
+import {createBacklogRepositories} from '../../../composition/backlog-repositories.js'
+import {BacklogMockServer} from '../../../shared/testing/backlog-mock-server.js'
+import {stubLogger} from '../../../shared/testing/stub-logger.js'
+import {updateExports} from './update-exports.js'
+
+const API_KEY = 'test-api-key'
+const PROJECT_KEY = 'TEST'
+const PROJECT_ID = 12_345
+
+describe('updateExports - downloadAttachmentsの伝播', () => {
+  const server = new BacklogMockServer()
+  let targetDir: string
+
+  beforeAll(() => server.start())
+  afterAll(() => server.stop())
+
+  beforeEach(async () => {
+    server.reset()
+    targetDir = await fs.mkdtemp(join(tmpdir(), 'backlog-update-test-'))
+    server.respond(`/api/v2/projects/${PROJECT_KEY}`, {body: {id: PROJECT_ID, projectKey: PROJECT_KEY}})
+  })
+
+  afterEach(async () => {
+    await fs.rm(targetDir, {force: true, recursive: true})
+  })
+
+  const writeSettings = async (settings: Record<string, unknown>) => {
+    await fs.writeFile(
+      join(targetDir, 'backlog-settings.json'),
+      JSON.stringify({domain: server.domain, projectIdOrKey: PROJECT_KEY, ...settings}),
+    )
+  }
+
+  const runUpdate = (flags: Record<string, unknown> = {}) =>
+    updateExports({createRepositories: createBacklogRepositories, logger: stubLogger}, targetDir, {
+      apiKey: API_KEY,
+      force: true,
+      ...flags,
+    })
+
+  it('設定ファイルのdownloadAttachmentsがWikiの添付ダウンロードに伝播すること', async () => {
+    await writeSettings({downloadAttachments: true, folderType: 'wiki'})
+    const binary = new Uint8Array([1, 2, 3, 4])
+    server.respond('/api/v2/wikis', {body: [{id: '111', name: 'WikiA', updated: '2026-01-02T00:00:00Z'}]})
+    server.respond('/api/v2/wikis/111', {
+      body: {attachments: [{id: 9, name: 'design.png', size: 4}], content: '本文', id: '111', name: 'WikiA'},
+    })
+    server.respond('/api/v2/wikis/111/attachments/9', {body: binary})
+
+    await runUpdate()
+
+    const saved = await fs.readFile(join(targetDir, 'attachments', 'WikiA', '9_design.png'))
+    expect(new Uint8Array(saved)).to.deep.equal(binary)
+    const content = await fs.readFile(join(targetDir, 'WikiA.md'), 'utf8')
+    expect(content).to.include('- [design.png](./attachments/WikiA/9_design.png)')
+  })
+
+  it('--downloadAttachmentsフラグがドキュメントの添付ダウンロードに伝播すること', async () => {
+    await writeSettings({folderType: 'document'})
+    const binary = new Uint8Array([5, 6])
+    server.respond('/api/v2/documents/tree', {
+      body: {activeTree: {children: [{children: [], id: 'docA', name: 'ドキュメントA'}], id: 'root'}},
+    })
+    server.respond('/api/v2/documents/docA', {
+      body: {
+        attachments: [
+          {created: '2026-01-01T00:00:00Z', createdUser: {id: 1, name: '作成者'}, id: 77, name: 'log.txt', size: 2},
+        ],
+        created: '2026-01-01T00:00:00Z',
+        createdUser: {id: 1, name: '作成者'},
+        id: 'docA',
+        json: '{}',
+        plain: '本文',
+        statusId: 1,
+        tags: [],
+        title: 'ドキュメントA',
+        updated: '2026-01-02T00:00:00Z',
+        updatedUser: {id: 1, name: '更新者'},
+      },
+    })
+    server.respond('/api/v2/documents/docA/attachments/77', {body: binary})
+
+    await runUpdate({downloadAttachments: true})
+
+    expect(existsSync(join(targetDir, 'attachments', 'ドキュメントA', '77_log.txt'))).to.be.true
+    const content = await fs.readFile(join(targetDir, 'ドキュメントA.md'), 'utf8')
+    expect(content).to.include('- [log.txt](./attachments/ドキュメントA/77_log.txt)')
+  })
+
+  it('フラグも設定もない場合は添付をダウンロードしないこと', async () => {
+    await writeSettings({folderType: 'wiki'})
+    server.respond('/api/v2/wikis', {body: [{id: '111', name: 'WikiA', updated: '2026-01-02T00:00:00Z'}]})
+    server.respond('/api/v2/wikis/111', {
+      body: {attachments: [{id: 9, name: 'design.png', size: 4}], content: '本文', id: '111', name: 'WikiA'},
+    })
+
+    await runUpdate()
+
+    expect(server.requestedPaths()).to.not.include('/api/v2/wikis/111/attachments/9')
+    expect(existsSync(join(targetDir, 'attachments'))).to.be.false
+  })
+})

--- a/src/modules/update/use-case/update-exports.ts
+++ b/src/modules/update/use-case/update-exports.ts
@@ -131,6 +131,7 @@ async function updateDirectory(deps: UpdateDeps, targetDir: string, flags: Updat
       {logger, wikiRepository},
       {
         domain: plan.domain,
+        downloadAttachments: plan.downloadAttachments,
         lastUpdated: plan.wikiIds ? undefined : plan.lastUpdated,
         outputDir: targetDir,
         projectIdOrKey: plan.projectIdOrKey,
@@ -152,6 +153,7 @@ async function updateDirectory(deps: UpdateDeps, targetDir: string, flags: Updat
       {
         documentIds: plan.documentIds,
         domain: plan.domain,
+        downloadAttachments: plan.downloadAttachments,
         lastUpdated: plan.documentIds ? undefined : plan.lastUpdated,
         outputDir: targetDir,
         projectId,

--- a/src/modules/wiki/domain/wiki-markdown.ts
+++ b/src/modules/wiki/domain/wiki-markdown.ts
@@ -1,5 +1,35 @@
+import {escapeLinkText} from '../../../shared/attachment.js'
 import {wrapBody} from '../../../shared/markdown/body-marker.js'
+import {WikiAttachment} from './wiki.js'
 
-export function buildWikiMarkdown(wikiName: string, backlogWikiUrl: string, content: string): string {
-  return `# ${wikiName}\n\n[Backlog Wiki Link](${backlogWikiUrl})\n\n${wrapBody(content || '（内容なし）')}`
+export interface WikiAttachmentsView {
+  items?: WikiAttachment[]
+  // ダウンロード済みの添付のみが持つ、Markdownからのローカル相対リンク
+  localLinks?: Map<number, string>
+}
+
+// ダウンロード済みの添付はローカルへの相対リンク付き、未ダウンロードはメタデータのみを出力する
+function buildAttachmentsSection(attachments: WikiAttachmentsView): string {
+  if (!attachments.items || attachments.items.length === 0) {
+    return ''
+  }
+
+  const lines = attachments.items.map((attachment) => {
+    const fileSize = `${(attachment.size / 1024).toFixed(1)} KB`
+    const link = attachments.localLinks?.get(attachment.id)
+    return link ? `- [${escapeLinkText(attachment.name)}](${link}) (${fileSize})` : `- ${attachment.name} (${fileSize})`
+  })
+
+  return `## 添付ファイル\n\n${lines.join('\n')}\n\n`
+}
+
+// 本文はBacklogの原文を維持する（添付参照記法の書き換えは行わない）
+export function buildWikiMarkdown(
+  wikiName: string,
+  backlogWikiUrl: string,
+  content: string,
+  attachments: WikiAttachmentsView = {},
+): string {
+  const attachmentsSection = buildAttachmentsSection(attachments)
+  return `# ${wikiName}\n\n[Backlog Wiki Link](${backlogWikiUrl})\n\n${attachmentsSection}${wrapBody(content || '（内容なし）')}`
 }

--- a/src/modules/wiki/domain/wiki-path.ts
+++ b/src/modules/wiki/domain/wiki-path.ts
@@ -1,11 +1,40 @@
 import path from 'node:path'
 
+import {attachmentFileName, encodeLinkDestination} from '../../../shared/attachment.js'
 import {backlogOrigin} from '../../../shared/backlog-url.js'
 import {sanitizeWikiFileName} from '../../../shared/file-name.js'
 import {ExpectedPaths} from '../../prune/domain/expected-paths.js'
+import {WikiAttachment} from './wiki.js'
 
 export function wikiRelativePath(wikiName: string): string {
   return `${sanitizeWikiFileName(wikiName)}.md`
+}
+
+// 添付の保存先はMarkdownと同じディレクトリの attachments/{Wikiファイル名}/ 配下。
+// Wiki名変更時は再ダウンロードになるが、Markdown本体（{Wiki名}.md）と同じ挙動で閲覧性を優先する
+function wikiAttachmentDirName(wikiName: string): string {
+  return path.basename(wikiRelativePath(wikiName), '.md')
+}
+
+export function wikiAttachmentRelativePath(
+  wikiName: string,
+  attachment: Pick<WikiAttachment, 'id' | 'name'>,
+): string {
+  return path.join(
+    path.dirname(wikiRelativePath(wikiName)),
+    'attachments',
+    wikiAttachmentDirName(wikiName),
+    attachmentFileName(attachment),
+  )
+}
+
+export function wikiAttachmentMarkdownLink(
+  wikiName: string,
+  attachment: Pick<WikiAttachment, 'id' | 'name'>,
+): string {
+  return encodeLinkDestination(
+    ['.', 'attachments', wikiAttachmentDirName(wikiName), attachmentFileName(attachment)].join('/'),
+  )
 }
 
 export function wikiUrl(domain: string, wikiId: string): string {

--- a/src/modules/wiki/domain/wiki-repository.ts
+++ b/src/modules/wiki/domain/wiki-repository.ts
@@ -1,6 +1,7 @@
 import {WikiDetail, WikiSummary} from './wiki.js'
 
 export interface WikiRepository {
+  downloadAttachment(wikiId: string, attachmentId: number): Promise<ArrayBuffer>
   fetchDetail(wikiId: string, projectIdOrKey: string): Promise<WikiDetail>
   fetchWikis(projectIdOrKey: string): Promise<WikiSummary[]>
 }

--- a/src/modules/wiki/domain/wiki.ts
+++ b/src/modules/wiki/domain/wiki.ts
@@ -4,7 +4,14 @@ export interface WikiSummary {
   updated: string
 }
 
+export interface WikiAttachment {
+  id: number
+  name: string
+  size: number
+}
+
 export interface WikiDetail {
+  attachments?: WikiAttachment[]
   content?: string
   id: string
   name: string

--- a/src/modules/wiki/repository/backlog-wiki-repository.ts
+++ b/src/modules/wiki/repository/backlog-wiki-repository.ts
@@ -4,6 +4,10 @@ import {WikiDetail, WikiSummary} from '../domain/wiki.js'
 
 export function newBacklogWikiRepository(client: BacklogHttpClient): WikiRepository {
   return {
+    async downloadAttachment(wikiId, attachmentId) {
+      return client.getBinary(`/wikis/${wikiId}/attachments/${attachmentId}`)
+    },
+
     async fetchDetail(wikiId, projectIdOrKey) {
       return client.getJson<WikiDetail>(`/wikis/${wikiId}`, {projectIdOrKey})
     },

--- a/src/modules/wiki/use-case/export-wikis.test.ts
+++ b/src/modules/wiki/use-case/export-wikis.test.ts
@@ -97,4 +97,89 @@ describe('exportWikis', () => {
     expect(server.requestedPaths()).to.not.include('/api/v2/wikis/111')
     expect(server.requestedPaths()).to.not.include('/api/v2/wikis/333')
   })
+
+  it('downloadAttachments指定時に添付を保存し、本文は原文のまま維持すること', async () => {
+    const binary = new Uint8Array([1, 2, 3, 4])
+    server.respond('/api/v2/wikis', {body: [{id: '111', name: 'WikiA', updated: '2026-01-02T00:00:00Z'}]})
+    server.respond('/api/v2/wikis/111', {
+      body: {
+        attachments: [{id: 9, name: 'design.png', size: 4}],
+        content: '説明\n![image][design.png]',
+        id: '111',
+        name: 'WikiA',
+      },
+    })
+    server.respond('/api/v2/wikis/111/attachments/9', {body: binary})
+
+    await exportWikis(
+      {logger: stubLogger, wikiRepository: newBacklogWikiRepository(client())},
+      {
+        domain: server.domain,
+        downloadAttachments: true,
+        outputDir,
+        projectIdOrKey: PROJECT_KEY,
+      },
+    )
+
+    const saved = await fs.readFile(join(outputDir, 'attachments', 'WikiA', '9_design.png'))
+    expect(new Uint8Array(saved)).to.deep.equal(binary)
+
+    const content = await fs.readFile(join(outputDir, 'WikiA.md'), 'utf8')
+    expect(content).to.include('## 添付ファイル')
+    expect(content).to.include('- [design.png](./attachments/WikiA/9_design.png) (0.0 KB)')
+    expect(content, '本文はBacklogの原文のまま維持されること').to.include('説明\n![image][design.png]')
+  })
+
+  it('階層Wikiの添付はMarkdownと同じディレクトリのattachmentsに保存されること', async () => {
+    server.respond('/api/v2/wikis', {body: [{id: '222', name: '運用/手順書', updated: '2026-01-02T00:00:00Z'}]})
+    server.respond('/api/v2/wikis/222', {
+      body: {
+        attachments: [{id: 10, name: 'manual.pdf', size: 2}],
+        content: '手順',
+        id: '222',
+        name: '運用/手順書',
+      },
+    })
+    server.respond('/api/v2/wikis/222/attachments/10', {body: new Uint8Array([5, 6])})
+
+    await exportWikis(
+      {logger: stubLogger, wikiRepository: newBacklogWikiRepository(client())},
+      {
+        domain: server.domain,
+        downloadAttachments: true,
+        outputDir,
+        projectIdOrKey: PROJECT_KEY,
+      },
+    )
+
+    expect(existsSync(join(outputDir, '運用', 'attachments', '手順書', '10_manual.pdf'))).to.be.true
+    const content = await fs.readFile(join(outputDir, '運用', '手順書.md'), 'utf8')
+    expect(content).to.include('- [manual.pdf](./attachments/手順書/10_manual.pdf)')
+  })
+
+  it('downloadAttachments未指定時はダウンロードせず、メタデータのみ記載すること', async () => {
+    server.respond('/api/v2/wikis', {body: [{id: '111', name: 'WikiA', updated: '2026-01-02T00:00:00Z'}]})
+    server.respond('/api/v2/wikis/111', {
+      body: {
+        attachments: [{id: 9, name: 'design.png', size: 2048}],
+        content: '本文',
+        id: '111',
+        name: 'WikiA',
+      },
+    })
+
+    await exportWikis(
+      {logger: stubLogger, wikiRepository: newBacklogWikiRepository(client())},
+      {
+        domain: server.domain,
+        outputDir,
+        projectIdOrKey: PROJECT_KEY,
+      },
+    )
+
+    expect(server.requestedPaths()).to.not.include('/api/v2/wikis/111/attachments/9')
+    const content = await fs.readFile(join(outputDir, 'WikiA.md'), 'utf8')
+    expect(content).to.include('- design.png (2.0 KB)')
+    expect(content).to.not.include('](./attachments')
+  })
 })

--- a/src/modules/wiki/use-case/export-wikis.ts
+++ b/src/modules/wiki/use-case/export-wikis.ts
@@ -2,12 +2,13 @@ import path from 'node:path'
 
 import {writeProgress} from '../../../shared/console/progress.js'
 import {Logger} from '../../../shared/ports.js'
-import {writeMarkdownFile} from '../../../shared/storage/markdown-store.js'
+import {fileSize, writeBinaryFile, writeMarkdownFile} from '../../../shared/storage/markdown-store.js'
 import {appendLog} from '../../../shared/storage/update-log.js'
 import {selectWikisToExport} from '../domain/wiki-filter.js'
 import {buildWikiMarkdown} from '../domain/wiki-markdown.js'
-import {wikiRelativePath, wikiUrl} from '../domain/wiki-path.js'
+import {wikiAttachmentMarkdownLink, wikiAttachmentRelativePath, wikiRelativePath, wikiUrl} from '../domain/wiki-path.js'
 import {WikiRepository} from '../domain/wiki-repository.js'
+import {WikiAttachment} from '../domain/wiki.js'
 
 export interface ExportWikisDeps {
   logger: Logger
@@ -16,6 +17,7 @@ export interface ExportWikisDeps {
 
 export interface ExportWikisOptions {
   domain: string
+  downloadAttachments?: boolean
   lastUpdated?: string
   outputDir: string
   projectIdOrKey: string
@@ -54,7 +56,17 @@ export async function exportWikis(deps: ExportWikisDeps, options: ExportWikisOpt
       const filePath = path.join(options.outputDir, wikiRelativePath(wiki.name))
       const backlogWikiUrl = wikiUrl(options.domain, wiki.id)
 
-      await writeMarkdownFile(filePath, buildWikiMarkdown(wiki.name, backlogWikiUrl, wikiDetail.content || ''))
+      const attachmentLinks = options.downloadAttachments
+        ? await downloadWikiAttachments(deps, wiki, wikiDetail.attachments ?? [], options.outputDir)
+        : undefined
+
+      await writeMarkdownFile(
+        filePath,
+        buildWikiMarkdown(wiki.name, backlogWikiUrl, wikiDetail.content || '', {
+          items: wikiDetail.attachments,
+          localLinks: attachmentLinks,
+        }),
+      )
       await appendLog(options.outputDir, `Wiki「${wiki.name}」を更新しました: ${backlogWikiUrl}`)
 
       writeProgress(`Wikiを保存中... (${index + 1}/${wikis.length}件)`)
@@ -65,4 +77,38 @@ export async function exportWikis(deps: ExportWikisDeps, options: ExportWikisOpt
   /* eslint-enable no-await-in-loop */
 
   logger.log('\nWikiのダウンロードが完了しました！')
+}
+
+// 保存できた添付のみリンク化する。個々の失敗は警告に留め、Wiki本体の保存は続行する
+async function downloadWikiAttachments(
+  deps: ExportWikisDeps,
+  wiki: {id: string; name: string},
+  attachments: WikiAttachment[],
+  outputDir: string,
+): Promise<Map<number, string>> {
+  const links = new Map<number, string>()
+
+  for (const attachment of attachments) {
+    const absolutePath = path.join(outputDir, wikiAttachmentRelativePath(wiki.name, attachment))
+    try {
+      // 添付IDは不変のため、サイズの一致するファイルが既にあれば再ダウンロードしない
+      // eslint-disable-next-line no-await-in-loop
+      if ((await fileSize(absolutePath)) !== attachment.size) {
+        // eslint-disable-next-line no-await-in-loop
+        const data = await deps.wikiRepository.downloadAttachment(wiki.id, attachment.id)
+        // eslint-disable-next-line no-await-in-loop
+        await writeBinaryFile(absolutePath, data)
+      }
+
+      links.set(attachment.id, wikiAttachmentMarkdownLink(wiki.name, attachment))
+    } catch (error) {
+      deps.logger.warn(
+        `Wiki「${wiki.name}」の添付ファイル「${attachment.name}」の取得に失敗しました: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      )
+    }
+  }
+
+  return links
 }

--- a/src/shared/attachment.test.ts
+++ b/src/shared/attachment.test.ts
@@ -1,0 +1,87 @@
+import {describe, expect, it} from 'vitest'
+
+import {attachmentFileName, encodeLinkDestination, rewriteInlineImages} from './attachment.js'
+
+describe('attachment - 添付ファイル共通処理', () => {
+  describe('attachmentFileName', () => {
+    it('添付IDを前置しサニタイズした名前を返すこと', () => {
+      expect(attachmentFileName({id: 10, name: '設計 資料.png'})).to.equal('10_設計_資料.png')
+    })
+  })
+
+  describe('encodeLinkDestination', () => {
+    it('丸括弧をパーセントエンコードすること', () => {
+      expect(encodeLinkDestination('./attachments/10_image_(3).png')).to.equal('./attachments/10_image_%283%29.png')
+    })
+  })
+
+  describe('rewriteInlineImages', () => {
+    const attachments = [
+      {id: 10, name: 'design.png'},
+      {id: 11, name: 'スクリーンショット 2026-06-18 12.37.25.png'},
+    ]
+    const links = new Map([
+      [10, './attachments/TEST-1/10_design.png'],
+      [11, './attachments/TEST-1/11_スクリーンショット_2026-06-18_12.37.25.png'],
+    ])
+
+    it('Markdown拡張記法 ![image][ファイル名] をローカルリンクに変換すること', () => {
+      const result = rewriteInlineImages('前文\n![image][design.png]\n後文', attachments, links)
+      expect(result).to.equal('前文\n![design.png](./attachments/TEST-1/10_design.png)\n後文')
+    })
+
+    it('スペース入り日本語ファイル名も変換すること', () => {
+      const result = rewriteInlineImages('![image][スクリーンショット 2026-06-18 12.37.25.png]', attachments, links)
+      expect(result).to.equal(
+        '![スクリーンショット 2026-06-18 12.37.25.png](./attachments/TEST-1/11_スクリーンショット_2026-06-18_12.37.25.png)',
+      )
+    })
+
+    it('Backlog記法 #image(ファイル名) をローカルリンクに変換すること', () => {
+      const result = rewriteInlineImages('#image(design.png)', attachments, links)
+      expect(result).to.equal('![design.png](./attachments/TEST-1/10_design.png)')
+    })
+
+    it('添付一覧にないファイル名の参照はそのまま残すこと', () => {
+      const text = '![image][unknown.png] と #image(other.png)'
+      expect(rewriteInlineImages(text, attachments, links)).to.equal(text)
+    })
+
+    it('ダウンロードされていない添付への参照はそのまま残すこと', () => {
+      const text = '![image][design.png]'
+      expect(rewriteInlineImages(text, attachments, new Map())).to.equal(text)
+      expect(rewriteInlineImages(text, attachments)).to.equal(text)
+    })
+
+    it('NFD（結合濁点）の参照名をNFCの添付名と照合できること', () => {
+      const nfdName = 'ドリンク.png'.normalize('NFD')
+      const result = rewriteInlineImages(
+        `![image][${nfdName}]`,
+        [{id: 20, name: 'ドリンク.png'.normalize('NFC')}],
+        new Map([[20, './attachments/TEST-1/20_ドリンク.png']]),
+      )
+      expect(result).to.equal(`![${nfdName}](./attachments/TEST-1/20_ドリンク.png)`)
+    })
+
+    it('ファイル名中の角括弧をエスケープすること', () => {
+      const result = rewriteInlineImages(
+        '#image(x]y.png)',
+        [{id: 30, name: 'x]y.png'}],
+        new Map([[30, './attachments/TEST-1/30_x_y.png']]),
+      )
+      expect(result).to.equal(String.raw`![x\]y.png](./attachments/TEST-1/30_x_y.png)`)
+    })
+
+    it('通常の参照リンク（添付名と一致しないラベル）を壊さないこと', () => {
+      const text = '![alt text][ref1]\n\n[ref1]: https://example.com/a.png'
+      expect(rewriteInlineImages(text, attachments, links)).to.equal(text)
+    })
+
+    it('1テキスト内の複数の記法をすべて変換すること', () => {
+      const result = rewriteInlineImages('![image][design.png] と #image(design.png)', attachments, links)
+      expect(result).to.equal(
+        '![design.png](./attachments/TEST-1/10_design.png) と ![design.png](./attachments/TEST-1/10_design.png)',
+      )
+    })
+  })
+})

--- a/src/shared/attachment.ts
+++ b/src/shared/attachment.ts
@@ -1,0 +1,54 @@
+import {sanitizeAttachmentFileName} from './file-name.js'
+
+// 課題・Wiki・ドキュメントの添付に共通する最小フィールド
+export interface AttachmentRef {
+  id: number
+  name: string
+}
+
+// 添付IDを前置して同名添付の衝突を防ぎ、存在チェックだけでDL済み判定できるようにする
+export function attachmentFileName(attachment: AttachmentRef): string {
+  return `${attachment.id}_${sanitizeAttachmentFileName(attachment.name)}`
+}
+
+// Markdownリンク先の丸括弧はインラインリンクを壊すためエンコードする
+export function encodeLinkDestination(linkPath: string): string {
+  return linkPath.replaceAll('(', '%28').replaceAll(')', '%29')
+}
+
+// ファイル名中の角括弧はリンク構文を壊すためエスケープする
+export function escapeLinkText(name: string): string {
+  return name.replaceAll('[', String.raw`\[`).replaceAll(']', String.raw`\]`)
+}
+
+// Backlogの添付画像インライン記法（Markdown拡張の ![alt][ファイル名] とBacklog記法の #image(ファイル名)）を
+// ダウンロード済みファイルへのローカルリンクに変換する。未ダウンロードの参照は壊さずそのまま残す
+export function rewriteInlineImages(
+  text: string,
+  attachments: AttachmentRef[] | undefined,
+  localLinks?: Map<number, string>,
+): string {
+  if (!text || !attachments || attachments.length === 0 || !localLinks || localLinks.size === 0) {
+    return text
+  }
+
+  // 同名添付が複数ある場合は記法から特定できないため先勝ちで解決する。
+  // 記法内のファイル名はNFD（macOSからのD&D等）で入ることがあるため、照合はNFC正規化で行う
+  const linkByName = new Map<string, string>()
+  for (const attachment of attachments) {
+    const link = localLinks.get(attachment.id)
+    const name = attachment.name.normalize('NFC')
+    if (link && !linkByName.has(name)) {
+      linkByName.set(name, link)
+    }
+  }
+
+  const toLocalImage = (match: string, name: string) => {
+    const link = linkByName.get(name.normalize('NFC'))
+    return link ? `![${escapeLinkText(name)}](${link})` : match
+  }
+
+  return text
+    .replaceAll(/!\[[^\]]*\]\[([^\]]+)\]/g, toLocalImage)
+    .replaceAll(/#image\(([^)]+)\)/g, toLocalImage)
+}


### PR DESCRIPTION
## 概要

課題で実装済みの `-d` / `--downloadAttachments` フラグ（#51）を Wiki・ドキュメントに拡張します。これにより、Backlogの主要3データ（課題・Wiki・ドキュメント）すべてで添付ファイルをローカルに保存できるようになります。

## 変更内容

### 添付ファイルのダウンロード
- **Wiki**: 詳細APIのレスポンスに含まれる `attachments` を利用（追加API呼び出しなし）。保存先は `attachments/{Wikiページ名}/`（階層Wikiは末尾のページ名、mdと同じディレクトリ）
- **ドキュメント**: `GET /documents/:id/attachments/:aid` でダウンロード（公式ドキュメント未記載だが公式SDKに存在するエンドポイント。実環境で動作確認済み）。保存先は `attachments/{ドキュメント名}/`
- どちらも名前ベースの保存先（改名時は再DLになるが、md本体と同じ挙動で閲覧性を優先）。ファイル名は `{添付ID}_{ファイル名}` で衝突回避・スキップ判定
- `## 添付ファイル` セクションにローカル相対リンクを記載（ドキュメントは既存の作成者・日時表示を維持）
- **本文はBacklogの原文のまま維持**（添付参照記法の書き換えは行わない）

### 基盤の変更
- 課題実装から添付共通処理を `src/shared/attachment.ts` に抽出（ファイル名生成・リンクエンコード・インライン画像変換）
- pruneの `.md` 添付保護を「attachmentsディレクトリを走査対象外にする」方式に一本化（Wiki/ドキュメントのpruneは一覧APIしか呼ばず期待パスを構築できないため）。これに伴い課題側の冗長になった期待パス登録を削除
- `wiki` / `document` コマンドに `-d` フラグ・設定保存を追加し、`all` / `update` からの伝播を配線（従来updateは課題にのみ伝播していた）

## テスト

- [x] Vitest 263件パス（+20件: Wiki DL/階層配置/原文維持、ドキュメント DL/フォルダ配下/原文維持、prune保護、update伝播の統合テスト3件、共通モジュールの単体テスト等）・lint・型チェック・e2e
- [x] 実環境（cm1.backlog.jp / PJ_CORTEX）で検証:
  - ドキュメント4件から添付7ファイル（30MBのPDF・丸括弧/日本語ファイル名含む）をDL、サイズ・形式一致を確認
  - ルート直下とフォルダ配下の両レイアウト、再実行時の再DLスキップ、設定の `update` 引き継ぎ
  - 本文が原文のまま維持されることを確認
- [x] 多観点レビュー（正しさ/セキュリティ/設計整合）を実施し、指摘を反映済み（wikiIdのパス利用廃止＝名前ベース化で解消、update伝播統合テスト追加、冗長コード削除）

## 補足

- `attachments` という名前のWiki階層・ドキュメントフォルダが存在する場合、pruneがそのディレクトリを保護対象と誤認して配下の `.md` を削除しなくなります（誤削除ではなく削除漏れ方向の安全側。レビューで確認済みの既知の制約）
- 共有ファイル（プロジェクトの「ファイル」機能）は対象外です

🤖 Generated with [Claude Code](https://claude.com/claude-code)