### PR TITLE
chore: v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ npm install -g backlog-exporter
 $ backlog-exporter COMMAND
 running command...
 $ backlog-exporter (--version)
-backlog-exporter/1.0.0 linux-x64 node-v22.23.1
+backlog-exporter/1.1.0 darwin-arm64 node-v22.22.2
 $ backlog-exporter --help [COMMAND]
 USAGE
   $ backlog-exporter COMMAND

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backlog-exporter",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backlog-exporter",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backlog-exporter",
   "description": "A new CLI generated with oclif",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "ShuntaToda",
   "bin": {
     "backlog-exporter": "bin/run.js"


### PR DESCRIPTION
## リリース内容

v1.0.0 以降の変更をまとめて v1.1.0 としてリリースします。マージすると自動でタグ・GitHub Release が作成され、npm に公開されます。

### 新機能

- **課題の添付ファイルダウンロード** `-d` / `--downloadAttachments`（#51）
  - 添付を `attachments/{課題キー}/{添付ID}_{ファイル名}` に保存し、Markdownにローカルリンクを記載
  - 本文・コメント内のインライン画像記法（`![image][ファイル名]` / `#image(ファイル名)`）をローカル画像リンクに変換
- **Wiki・ドキュメントの添付ファイルダウンロード**（#54）
  - Wiki: `attachments/{Wiki名}/`、ドキュメント: `attachments/{ドキュメント名}/` に保存
  - 本文はBacklogの原文のまま維持し、`## 添付ファイル` セクションのリンクからアクセス
  - `all` / `update` からの伝播と `backlog-settings.json` への設定保存に対応

### 改善

- **レート制限待機の一本化**（#52）: 固定15秒待機（100リクエストごと）を撤廃し、429受信時に `X-RateLimit-Reset` まで待機する方式へ。エクスポートが高速化し、フリープランでも完走可能に
- **進捗表示の修正**（#53): 前のメッセージの残骸で表示が崩れる問題を修正（ANSI行消去）。非TTY環境では1行ずつ出力

🤖 Generated with [Claude Code](https://claude.com/claude-code)